### PR TITLE
Use file instead of link in dependencies

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@kitsuyui/react-clock": "link:../../packages/clock",
-    "@kitsuyui/react-timer": "link:../../packages/timer"
+    "@kitsuyui/react-clock": "file:../../packages/clock",
+    "@kitsuyui/react-timer": "file:../../packages/timer"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -18,8 +18,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^7.0.8",
-    "@kitsuyui/react-clock": "link:../packages/clock",
-    "@kitsuyui/react-timer": "link:../packages/timer"
+    "@kitsuyui/react-clock": "file:../packages/clock",
+    "@kitsuyui/react-timer": "file:../packages/timer"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,7 +1680,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kitsuyui/react-clock@link:packages/clock":
+"@kitsuyui/react-clock@file:packages/clock":
   version "0.0.0"
   dependencies:
     luxon "^3.3.0"
@@ -1688,7 +1688,7 @@
     react-dom "^18.2.0"
     react-use "^17.4.0"
 
-"@kitsuyui/react-timer@link:packages/timer":
+"@kitsuyui/react-timer@file:packages/timer":
   version "0.0.0"
   dependencies:
     luxon "^3.3.0"


### PR DESCRIPTION
If you use link in dependencies of package.json, you will get an error when you run yarn publish.
Use file instead.

There are situations where you want it to behave as a link rather than a file when running locally.
In that case, instead of writing link in package.json, use yarn link to create a symbolic link.
