### PR TITLE
Remove coverage from prettier targets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ dist-ssr
 logs
 *.log
 .DS_Store
+coverage


### PR DESCRIPTION
Files related to test coverage do not need to be formatted by prettier and are not managed by Git.
So remove it from prettier targets.
