### PR TITLE
Fix: Sweep and tick

### DIFF
--- a/packages/clock/src/step/index.ts
+++ b/packages/clock/src/step/index.ts
@@ -27,7 +27,7 @@ export function calcHMS(
 export function tickHMS(date: Date, timezone: string): HMS {
   const datetime = DateTime.fromJSDate(date)
   const dt = datetime.setZone(timezone)
-  const hour = dt.hour
+  const hour = dt.hour + dt.minute / 60
   const minute = dt.minute
   const second = dt.second
   return { hour, minute, second }

--- a/packages/clock/src/step/test.ts
+++ b/packages/clock/src/step/test.ts
@@ -10,7 +10,7 @@ test('tickHMS returns HMS', () => {
 
   const dt2 = new Date('2021-01-01T10:08:14Z')
   expect(tickHMS(dt2, 'Asia/Tokyo')).toEqual({
-    hour: 19,
+    hour: 19.133333333333333,
     minute: 8,
     second: 14,
   })


### PR DESCRIPTION
Analog clock has 2 types of hands: `sweep` and `tick`.
`sweep` is a hand that moves slowly, and `tick` is a hand that moves quickly.
The implementation of `tick` does not match the movement of a realistic clock, so fix it.

 ### Problem

- The current short hand moves 1/12 rotation per hour

 ### Expected

- The short hand moves 1/60 rotation per minute instead of 1/12 rotation per hour
