### PR TITLE
Additional fix: Sweep and tick

### DIFF
--- a/packages/clock/src/step/index.ts
+++ b/packages/clock/src/step/index.ts
@@ -27,7 +27,9 @@ export function calcHMS(
 export function tickHMS(date: Date, timezone: string): HMS {
   const datetime = DateTime.fromJSDate(date)
   const dt = datetime.setZone(timezone)
-  const hour = dt.hour + dt.minute / 60
+  // hour hand moves 1 step every 12 minutes
+  const m = (dt.minute / 12) | 0
+  const hour = dt.hour + m / 5
   const minute = dt.minute
   const second = dt.second
   return { hour, minute, second }

--- a/packages/clock/src/step/test.ts
+++ b/packages/clock/src/step/test.ts
@@ -10,7 +10,7 @@ test('tickHMS returns HMS', () => {
 
   const dt2 = new Date('2021-01-01T10:08:14Z')
   expect(tickHMS(dt2, 'Asia/Tokyo')).toEqual({
-    hour: 19.133333333333333,
+    hour: 19,
     minute: 8,
     second: 14,
   })


### PR DESCRIPTION
There was a mistake in https://github.com/kitsuyui/react-playground/pull/80 .
Fix it.

The range of the short hand should also be divided into 60 minutes.
Therefore, the short hand should rotate once every 12 minutes.
