### PR TITLE
Fix: GitHub Workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  push:
+  pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,6 @@
 name: Spellcheck
-on: [push]
+on:
+  - pull_request
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test-vrt.yml
+++ b/.github/workflows/test-vrt.yml
@@ -1,5 +1,6 @@
 name: test-vrt
-on: push
+on:
+  - pull_request
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: test
-on: push
+on:
+  - pull_request
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Workflow was triggered only when push event was fired.
Now it is also triggered when pull_request event is fired.
This enables external contributors to run tests when they send pull requests.
(push event is fired when push is done to forked repository, but push event is not fired when push is done to kitsuyui's repository)
