### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.node-version == '20.x'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests


### PR DESCRIPTION
Reverts kitsuyui/react-playground#213

v4 is currently in beta.

https://github.com/codecov/codecov-action/issues/1089

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```