### PR TITLE
Add TextField and TextArea

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package_name: [clock, timer, stopwatch, dekamoji, wavebox, measure, treemap, components, style-bulma]
+        package_name: [clock, timer, stopwatch, dekamoji, textfield, wavebox, measure, treemap, components, style-bulma]
 
     steps:
       - uses: actions/checkout@v4

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -14,6 +14,7 @@
     "@kitsuyui/react-treemap": "workspace:^",
     "@kitsuyui/react-wavebox": "workspace:^",
     "@kitsuyui/react-style-bulma": "workspace:^",
+    "@kitsuyui/react-textfield": "workspace:^",
     "@playwright/test": "^1.37.1",
     "@storybook/addon-essentials": "^7.4.0",
     "@storybook/addon-interactions": "^7.4.0",

--- a/examples/storybook/stories/textfield/Introduction.mdx
+++ b/examples/storybook/stories/textfield/Introduction.mdx
@@ -1,0 +1,57 @@
+# TextArea and TextField
+
+import { Canvas, Meta } from "@storybook/blocks";
+
+import * as textAreaExample from "./TextAreaExample.stories";
+import * as textFieldExample from "./TextFieldExample.stories";
+
+<Meta title="Base/TextField/Introduction" />
+
+<Canvas of={textFieldExample.Default} />
+
+```jsx
+<TextField value="あいうえお" placeholder="🔍 something">
+```
+
+<Canvas of={textAreaExample.Default} />
+
+```jsx
+<TextArea value="あいうえお"></TextArea>
+```
+
+## Concept
+
+This package provides a text field component for React.
+
+It is very pure and similar with the default `<input type="text">` element and `<textarea>` element.
+
+So you can pass the same props as those elements. (i.e. `disabled`, `placeholder`, `maxLength`, `minLength`, `required`, `pattern`, `readOnly`, `autoComplete`, `autoFocus`, `name`, `id`, `className`, `style`, ..., etc.)
+This means, you can use this component as a drop-in replacement for those elements.
+
+The big difference is that this component how to handle the events.
+In default browser elements (`<input type="text">` and `<textarea>`), the `onChange` event is fired in every key press.
+But when you are using IME or something special input method, the `onChange` event is fired in every key press even if the input is not completed or text conversion is not completed. (e.g. Japanese IME, Chinese IME, espanso, etc.)
+This component calls the `onInput` handler `(text: string) => void` only when the input is completed or text conversion is completed. (Internally, it uses `CompositionEvent` to detect the completion of input or text conversion)
+
+Warning: This component has no effect to prevent the re-rendering of parent component.
+This means, if this component is re-created by parent component, the input may lost text conversion state.
+
+## Installation
+
+Each component is published as a separate package.
+
+Use npm, yarn or pnpm to install.
+
+```sh
+$ npm install @kitsuyui/react-textfield
+```
+
+```sh
+$ yarn add @kitsuyui/react-textfield
+```
+
+```sh
+$ pnpm add @kitsuyui/react-textfield
+```
+
+## Usage

--- a/examples/storybook/stories/textfield/TextAreaExample.stories.tsx
+++ b/examples/storybook/stories/textfield/TextAreaExample.stories.tsx
@@ -1,0 +1,24 @@
+import { TextArea } from "@kitsuyui/react-textfield";
+import React from "react";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TextArea> = {
+  title: "Base/TextField/TextArea/Example",
+  component: TextArea,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const Default: Story = {
+  args: {
+    value: "あいうえお",
+  },
+  decorators: [
+    (Story) => {
+      return <Story />;
+    },
+  ],
+};

--- a/examples/storybook/stories/textfield/TextFieldExample.stories.tsx
+++ b/examples/storybook/stories/textfield/TextFieldExample.stories.tsx
@@ -1,0 +1,25 @@
+import { TextField } from "@kitsuyui/react-textfield";
+import React from "react";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TextField> = {
+  title: "Base/TextField/TextField/Example",
+  component: TextField,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {
+  args: {
+    value: "",
+    placeholder: "🔍 something",
+  },
+  decorators: [
+    (Story) => {
+      return <Story />;
+    },
+  ],
+};

--- a/packages/textfield/.prettierrc.js
+++ b/packages/textfield/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('@kitsuyui/prettier-config'),
+}

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -1,0 +1,52 @@
+# @kitsuyui/react-textfield
+
+[![npm version](https://badge.fury.io/js/@kitsuyui%2Freact-textfield.svg)](https://badge.fury.io/js/@kitsuyui%2Freact-textfield)
+
+This package provides a text field component for React.
+
+It is very pure and similar with the default `<input type="text">` element and `<textarea>` element.
+
+So you can pass the same props as those elements. (i.e. `disabled`, `placeholder`, `maxLength`, `minLength`, `required`, `pattern`, `readOnly`, `autoComplete`, `autoFocus`, `name`, `id`, `className`, `style`, ..., etc.)
+This means, you can use this component as a drop-in replacement for those elements.
+
+The big difference is that this component how to handle the events.
+In default browser elements (`<input type="text">` and `<textarea>`), the `onChange` event is fired in every key press.
+But when you are using IME or something special input method, the `onChange` event is fired in every key press even if the input is not completed or text conversion is not completed. (e.g. Japanese IME, Chinese IME, espanso, etc.)
+This component calls the `onInput` handler `(text: string) => void` only when the input is completed or text conversion is completed. (Internally, it uses `CompositionEvent` to detect the completion of input or text conversion)
+
+Warning: This component has no effect to prevent the re-rendering of parent component.
+This means, if this component is re-created by parent component, the input may lost text conversion state.
+
+## Demo
+
+Storybook: https://react-playground.storybook.kitsuyui.com/
+
+## Installation
+
+### npm
+
+```sh
+npm install @kitsuyui/react-textfield
+```
+
+### yarn
+
+```sh
+yarn add @kitsuyui/react-textfield
+```
+
+### pnpm
+
+```sh
+pnpm add @kitsuyui/react-textfield
+```
+
+## Reference
+
+- https://maku.blog/p/cv6fpx7/
+- https://gist.github.com/KurtGokhan/9aafd8e83c9bc6a2946fe2dc7f2c1d19
+- https://qiita.com/pochman/items/5b69ebedf4465f93c2f1
+
+## License
+
+MIT

--- a/packages/textfield/jest.config.ts
+++ b/packages/textfield/jest.config.ts
@@ -1,0 +1,2 @@
+// https://jestjs.io/docs/configuration
+export default require('@kitsuyui/jest-config')

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@kitsuyui/react-textfield",
+  "version": "0.0.0",
+  "description": "A component that wrapped HTMLInputElement",
+  "license": "MIT",
+  "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "format:eslint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "format:prettier": "prettier --write . --ignore-path ../../.gitignore",
+    "lint:type": "tsc --noEmit --project .",
+    "lint:eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:prettier": "prettier --check . --ignore-path ../../.gitignore",
+    "test": "jest --watchAll=false --collect-coverage"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-use": "^17.4.0"
+  },
+  "devDependencies": {
+    "@kitsuyui/eslint-config": "workspace:^",
+    "@kitsuyui/jest-config": "workspace:^",
+    "@kitsuyui/prettier-config": "workspace:^",
+    "@kitsuyui/tsup-config": "workspace:^",
+    "@types/node": "^20.5.7",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "jest": "^29.6.4",
+    "tsup": "^7.2.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/textfield/src/TextArea.tsx
+++ b/packages/textfield/src/TextArea.tsx
@@ -1,0 +1,62 @@
+import { Ref, useCallback, useRef, useState } from 'react'
+import React from 'react'
+
+import { useCombinedRefs } from './utils'
+
+type WrappedProps = React.DetailedHTMLProps<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  HTMLTextAreaElement
+>
+type alternateProps = {
+  ref?: Ref<HTMLTextAreaElement>
+  onInput?: (value: string) => void
+  value?: string
+}
+
+type excludeProps =
+  | 'onChange'
+  | 'onCompositionStart'
+  | 'onCompositionUpdate'
+  | 'onCompositionEnd'
+  | 'onCompositionStartCapture'
+  | 'onCompositionUpdateCapture'
+  | 'onCompositionEndCapture'
+  | 'value'
+
+type WrapperProps = Omit<WrappedProps, excludeProps> & alternateProps
+
+export const TextArea = (props: WrapperProps) => {
+  const { onInput } = props
+  const [inputtingValue, setInputtingValue] = useState(props.value ?? '')
+  const [isInputting, setIsInputting] = useState(false)
+
+  const innerRef = useRef<HTMLTextAreaElement>(null!)
+  const ref = useCombinedRefs(innerRef, props.ref)
+
+  const propsExcludedWrapperProps = {
+    ...props,
+    ref: undefined,
+    onInput: undefined,
+  }
+
+  const handle = useCallback(() => {
+    const text = innerRef.current.value
+    setInputtingValue(text)
+    if (isInputting) return
+    onInput?.(text)
+  }, [isInputting, onInput])
+
+  return (
+    <textarea
+      {...propsExcludedWrapperProps}
+      ref={ref}
+      onCompositionStart={() => setIsInputting(true)}
+      onCompositionEnd={() => {
+        setIsInputting(false)
+        onInput?.(inputtingValue)
+      }}
+      onChange={handle}
+      value={inputtingValue}
+    ></textarea>
+  )
+}

--- a/packages/textfield/src/TextField.tsx
+++ b/packages/textfield/src/TextField.tsx
@@ -1,0 +1,66 @@
+import { Ref, useCallback, useRef, useState } from 'react'
+import React from 'react'
+
+import { useCombinedRefs } from './utils'
+
+// HTMLInputElement
+type WrappedProps = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>
+type alternateProps = {
+  ref?: Ref<HTMLInputElement>
+  onInput?: (value: string) => void
+  value: string
+}
+
+type excludeProps =
+  | 'onChange'
+  | 'onCompositionStart'
+  | 'onCompositionUpdate'
+  | 'onCompositionEnd'
+  | 'onCompositionStartCapture'
+  | 'onCompositionUpdateCapture'
+  | 'onCompositionEndCapture'
+  | 'value'
+  | 'type'
+
+type WrapperProps = Omit<WrappedProps, excludeProps> & alternateProps
+
+export const TextField = (props: WrapperProps) => {
+  const { onInput } = props
+  const [inputtingValue, setInputtingValue] = useState(props.value ?? '')
+  const [isInputting, setIsInputting] = useState(false)
+
+  const innerRef = useRef<HTMLInputElement>(null!)
+  const ref = useCombinedRefs(innerRef, props.ref)
+
+  const propsExcludedWrapperProps = {
+    ...props,
+    ref: undefined,
+    value: undefined,
+    onInput: undefined,
+  }
+
+  const handle = useCallback(() => {
+    const text = innerRef.current.value
+    setInputtingValue(text)
+    if (isInputting) return
+    onInput?.(text)
+  }, [isInputting, onInput])
+
+  return (
+    <input
+      {...propsExcludedWrapperProps}
+      type="text"
+      ref={ref}
+      value={inputtingValue}
+      onCompositionStart={() => setIsInputting(true)}
+      onCompositionEnd={() => {
+        setIsInputting(false)
+        onInput?.(inputtingValue)
+      }}
+      onChange={handle}
+    />
+  )
+}

--- a/packages/textfield/src/index.ts
+++ b/packages/textfield/src/index.ts
@@ -1,0 +1,2 @@
+export { TextField } from './TextField'
+export { TextArea } from './TextArea'

--- a/packages/textfield/src/test.tsx
+++ b/packages/textfield/src/test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { TextArea } from './TextArea'
+import { TextField } from './TextField'
+
+test('render TextArea', () => {
+  render(<TextArea value={`あいうえお`} />)
+  const element = screen.getAllByText(/あ/)
+  expect(element[0]).toBeInstanceOf(HTMLTextAreaElement)
+})
+
+test('render TextField', () => {
+  render(<TextField value={'あ'} placeholder={'🔍'} />)
+  const element = screen.getByPlaceholderText(/🔍/)
+  expect(element).toBeInstanceOf(HTMLInputElement)
+})

--- a/packages/textfield/src/utils/index.ts
+++ b/packages/textfield/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './refs'

--- a/packages/textfield/src/utils/refs.ts
+++ b/packages/textfield/src/utils/refs.ts
@@ -1,0 +1,43 @@
+// Combine multiple refs into one
+// For when user wants to pass a ref to the component but also wants to use the ref internally.
+// original: https://gist.github.com/KurtGokhan/9aafd8e83c9bc6a2946fe2dc7f2c1d19
+
+import { ForwardedRef, useMemo } from 'react'
+
+type OptionalRef<T> = ForwardedRef<T> | undefined
+
+type Cleanup = (() => void) | undefined | void
+
+/**
+ * This hook combines multiple refs into one.
+ * @param refs
+ * @returns combined ref
+ */
+export const useCombinedRefs = <T>(...refs: OptionalRef<T>[]) => {
+  return useMemo(() => {
+    if (refs.every((ref) => ref == null)) {
+      return null
+    }
+    return (node: T) => {
+      refs.forEach((ref) => {
+        if (ref) setRef(ref, node)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, refs)
+}
+
+const setRef = <T>(ref: OptionalRef<T>, value: T): Cleanup => {
+  if (!ref) return
+
+  if (typeof ref === 'function') {
+    ref(value)
+    return
+  }
+
+  try {
+    ref.current = value
+  } catch (error) {
+    throw new Error(`Cannot assign value '${value}' to ref '${ref}'`)
+  }
+}

--- a/packages/textfield/tsconfig.json
+++ b/packages/textfield/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/textfield/tsup.config.ts
+++ b/packages/textfield/tsup.config.ts
@@ -1,0 +1,2 @@
+import config from '@kitsuyui/tsup-config'
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@kitsuyui/react-style-bulma':
         specifier: workspace:^
         version: link:../../packages/style-bulma
+      '@kitsuyui/react-textfield':
+        specifier: workspace:^
+        version: link:../../packages/textfield
       '@kitsuyui/react-timer':
         specifier: workspace:^
         version: link:../../packages/timer
@@ -461,6 +464,49 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@kitsuyui/eslint-config':
+        specifier: workspace:^
+        version: link:../../config/eslint-config
+      '@kitsuyui/jest-config':
+        specifier: workspace:^
+        version: link:../../config/jest-config
+      '@kitsuyui/prettier-config':
+        specifier: workspace:^
+        version: link:../../config/prettier-config
+      '@kitsuyui/tsup-config':
+        specifier: workspace:^
+        version: link:../../config/tsup-config
+      '@types/node':
+        specifier: ^20.5.7
+        version: 20.6.4
+      '@types/react':
+        specifier: ^18.2.21
+        version: 18.2.22
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.7
+      jest:
+        specifier: ^29.6.4
+        version: 29.7.0(@types/node@20.6.4)(ts-node@10.9.1)
+      tsup:
+        specifier: ^7.2.0
+        version: 7.2.0(typescript@5.2.2)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
+
+  packages/textfield:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      react-use:
+        specifier: ^17.4.0
+        version: 17.4.0(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@kitsuyui/eslint-config':
         specifier: workspace:^

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,11 @@
         "packages/react-treemap/dist/**"
       ]
     },
+    "@kitsuyui/react-textfield#build": {
+      "outputs": [
+        "packages/react-textfield/dist/**"
+      ]
+    },
     "@kitsuyui/react-wavebox#build": {
       "outputs": [
         "packages/react-wavebox/dist/**"
@@ -47,6 +52,7 @@
         "@kitsuyui/react-timer#build",
         "@kitsuyui/react-stopwatch#build",
         "@kitsuyui/react-dekamoji#build",
+        "@kitsuyui/react-textfield#build",
         "@kitsuyui/react-measure#build",
         "@kitsuyui/react-treemap#build",
         "@kitsuyui/react-wavebox#build"


### PR DESCRIPTION
Add components that wrap `<input type="text">` and `<textarea>`.
`<input type="text">` and `<textarea>` are very fundamental components, but
When handling input events in React, it may interfere with IME input.

For example, when implementing an incremental search, the value of the text box being input is used for searching.
When providing a function such as a suggestion, the IME may reflect the string during conversion.

If this happens, the string being input is overwritten by the string set by setState in the event handler.
This is because React redraws when the props passed from the parent component are changed, so the value of the child component is dragged around.
Because it will be changed.

To avoid this problem, do not execute the event handler while the IME is being converted, and execute the event handler when the conversion is completed.
This package provides components to avoid such problems.
`<TextField>` and `<TextArea>` are components that wrap `<input type="text">` and `<textarea>` thinly.
Therefore, attributes such as `placeholder`, `disabled`, and `style` 
<img width="893" alt="Screenshot 2023-10-10 at 3 31 48" src="https://github.com/kitsuyui/react-playground/assets/2596972/10a976ca-0c20-4ec2-8be7-4fd62ab99e1c">
can be used as they are.

