### PR TITLE
The build artifacts are included in the coverage target. Exclude them.

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,4 +20,5 @@ export default {
   moduleNameMapper: {
     '^.+\\.(css|scss)$': 'identity-obj-proxy',
   },
+  collectCoverageFrom: ['packages/*/src/**/*.(tsx|ts)'],
 }


### PR DESCRIPTION
The build artifacts are only derived files and are not managed by Git.
I only want to measure the coverage of the source code that is the basis.
It can be specified in jest.config.ts. Do that.
