### PR TITLE
Switch dev and build options

### DIFF
--- a/packages/clock/package.json
+++ b/packages/clock/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/dekamoji/package.json
+++ b/packages/dekamoji/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/editablelabel/package.json
+++ b/packages/editablelabel/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/measure/package.json
+++ b/packages/measure/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/stopwatch/package.json
+++ b/packages/stopwatch/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/style-bulma/package.json
+++ b/packages/style-bulma/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/packages/wavebox/package.json
+++ b/packages/wavebox/package.json
@@ -19,7 +19,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup --config ../../tsup.config.mjs",
+    "build": "tsup --config ../../tsup.config.mjs --clean",
     "dev": "tsup --config ../../tsup.config.mjs --watch"
   },
   "dependencies": {

--- a/tsup.config.mjs
+++ b/tsup.config.mjs
@@ -7,7 +7,6 @@ export default defineConfig({
     '!./src/**/*.test.{ts,tsx}',
     '!./src/**/test.{ts,tsx}',
   ],
-  clean: true,
   sourcemap: true,
   dts: true,
 })


### PR DESCRIPTION
- pnpm dev does not need clean because it needs continuous build during development.
- pnpm build needs clean because it needs build for release or for release preparation.
