### PR TITLE
Add TreemapContext to Treemap

### DIFF
--- a/examples/storybook/stories/treemap/Direction.stories.tsx
+++ b/examples/storybook/stories/treemap/Direction.stories.tsx
@@ -1,0 +1,92 @@
+import { Treemap, TreemapContext } from '@kitsuyui/react-treemap'
+import React from 'react'
+import { useContext } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const directionNames = ['right', 'down', 'left', 'up'] as const
+type Direction = typeof directionNames[number]
+const directionToString = (direction: Direction) => {
+    switch (direction) {
+        case 'right':
+            return '→'
+        case 'down':
+            return '↓'
+        case 'left':
+            return '←'
+        case 'up':
+            return '↑'
+    }
+}
+
+const ExampleView = () => {
+    const rect = useContext(TreemapContext)
+    const directionStr = rect.nextDirection ? directionToString(rect.nextDirection) : ''
+    const continueBorderStyle = '1px dotted gray'
+    const uncontinueBorderStyle = '2px solid black'
+    return (
+        <div style={{
+            width: '100%',
+            height: '100%',
+            borderLeft: rect.continueDirection.left ? continueBorderStyle : uncontinueBorderStyle,
+            borderTop: rect.continueDirection.up ? continueBorderStyle : uncontinueBorderStyle,
+            borderRight: rect.continueDirection.right ? continueBorderStyle : uncontinueBorderStyle,
+            borderBottom: rect.continueDirection.down ? continueBorderStyle : uncontinueBorderStyle,
+        }}>
+            {`(x, y): (${rect.x}, ${rect.y})`}<br />
+            {`W×H: ${rect.w}×${rect.h}`}<br />
+            {`index: ${rect.index}`}<br />
+            {`previousDirection: ${rect.previousDirection}`}<br />
+            {`nextDirection: ${rect.nextDirection}`}<br />
+            {`direction: ${directionStr}`}<br />
+        </div>
+    )
+}
+
+const WeightedItems = [...Array(10)]
+    .map((_, i) => i + 1)
+    .map((i) => ({
+        weight: 1.1 ** i,
+        element: <ExampleView />,
+    }))
+WeightedItems.sort((a, b) => b.weight - a.weight)
+
+const TreemapExample = (
+    props: {
+        verticalFirst?: boolean
+        aspectRatio?: number
+        boustrophedon?: boolean
+    } = {
+            verticalFirst: true,
+            aspectRatio: 16 / 9,
+            boustrophedon: false,
+        }
+) => {
+    return <Treemap weightedItems={WeightedItems} {...props} />
+}
+
+const meta: Meta<typeof TreemapExample> = {
+    title: 'Base/Treemap/Direction',
+    component: TreemapExample,
+}
+
+export default meta
+type Story = StoryObj<typeof TreemapExample>
+
+export const Default: Story = {
+    args: {
+        verticalFirst: false,
+        aspectRatio: 16 / 9,
+        boustrophedon: true,
+    },
+    parameters: {
+        layout: 'fullscreen',
+        flexDirection: 'column',
+        docs: {
+            story: {
+                inline: false,
+                iframeHeight: 800,
+            },
+        },
+    },
+}

--- a/packages/treemap/src/index.ts
+++ b/packages/treemap/src/index.ts
@@ -1,1 +1,1 @@
-export { Treemap } from './treemap'
+export { Treemap, TreemapContext } from './treemap'

--- a/packages/treemap/src/treemap.tsx
+++ b/packages/treemap/src/treemap.tsx
@@ -8,15 +8,108 @@ interface Rect {
   h: number
 }
 
+type Direction = 'right' | 'down' | 'left' | 'up'
+
+interface ContinueDirection {
+  right: boolean
+  down: boolean
+  left: boolean
+  up: boolean
+}
+
+interface RectCursor {
+  index: number
+  previousDirection: Direction | null
+  nextDirection: Direction | null
+  continueDirection: ContinueDirection
+}
+
+type RectInfo = Rect & RectCursor
+
 interface WeightedItem {
   weight: number
   element: JSX.Element
 }
 
 interface RectItem {
-  rect: Rect
+  rect: RectInfo
   element: JSX.Element
 }
+
+const NULL_CONTINUE_DIRECTION = {
+  right: false,
+  down: false,
+  left: false,
+  up: false,
+} as const
+
+const NULL_RECT_INFO = {
+  x: 0,
+  y: 0,
+  w: 0,
+  h: 0,
+  index: 0,
+  previousDirection: null,
+  nextDirection: null,
+  continueDirection: NULL_CONTINUE_DIRECTION,
+} as const
+
+export const TreemapContext = React.createContext<RectInfo>(NULL_RECT_INFO)
+
+const nextBoustrophedonDirection = (rect1: Rect, rect2: Rect): Direction => {
+  if (rect1.x + rect1.w <= rect2.x) return 'right'
+  if (rect1.x >= rect2.x + rect2.w) return 'left'
+  if (rect1.y + rect1.h <= rect2.y) return 'down'
+  if (rect1.y >= rect2.y + rect2.h) return 'up'
+  return 'right'
+}
+
+const previousBoustrophedonDirection = (rect1: Rect, rect2: Rect): Direction => {
+  return nextBoustrophedonDirection(rect2, rect1)
+}
+
+const invertDirection = (direction: Direction): Direction => {
+  switch (direction) {
+    case 'right':
+      return 'left'
+    case 'down':
+      return 'up'
+    case 'left':
+      return 'right'
+    case 'up':
+      return 'down'
+  }
+}
+
+const rectsToRectInfos = (rects: Rect[]): RectInfo[] => {
+  const rectInfos: RectInfo[] = rects.map((rect, index) => ({
+    ...rect,
+    index,
+    previousDirection: null,
+    nextDirection: null,
+    continueDirection: {
+      right: false,
+      down: false,
+      left: false,
+      up: false,
+    },
+  }))
+  for (let i = 0; i < rectInfos.length; i++) {
+    const rectInfo = rectInfos[i]
+    const nextRectInfo = rectInfos[i + 1]
+    if (nextRectInfo) {
+      rectInfo.nextDirection = nextBoustrophedonDirection(rectInfo, nextRectInfo)
+      rectInfo.continueDirection[rectInfo.nextDirection] = true
+      nextRectInfo.previousDirection = previousBoustrophedonDirection(
+        rectInfo,
+        nextRectInfo
+      )
+      nextRectInfo.continueDirection[nextRectInfo.previousDirection] = true
+    }
+  }
+  return rectInfos
+}
+
 
 export const Treemap = (props: {
   weightedItems: WeightedItem[]
@@ -35,7 +128,7 @@ export const Treemap = (props: {
   >(null)
 
   useEffect(() => {
-    ;(async () => {
+    ; (async () => {
       if (dividing) return
       const d = await import('@kitsuyui/rectangle-dividing')
       setDividing(d)
@@ -69,7 +162,8 @@ export const Treemap = (props: {
     dividing,
   ])
 
-  const items = zip(weightedItems, inAreas).map(([item, rect]) => ({
+  const rectInfos = rectsToRectInfos(inAreas)
+  const items = zip(weightedItems, rectInfos).map(([item, rect]) => ({
     element: item.element,
     rect,
   }))
@@ -98,22 +192,24 @@ const TreemapByRect = (props: { items: RectItem[] }) => {
   const { items } = props
   return (
     <>
-      {items.map(({ element, rect: { x, y, w, h } }, i) => (
-        <div
-          // biome-ignore lint/suspicious/noArrayIndexKey: FIXME: TODO: temporary ignore for migration
-          key={i}
-          style={{
-            position: 'absolute',
-            overflow: 'hidden',
-            width: `${w}px`,
-            height: `${h}px`,
-            left: `${x}px`,
-            top: `${y}px`,
-          }}
-        >
-          {element}
-        </div>
-      ))}
+      {items.map(({ element, rect }) => {
+        const { x, y, w, h, index } = rect
+        return (<TreemapContext.Provider value={rect}>
+          <div
+            key={index}
+            style={{
+              position: 'absolute',
+              overflow: 'hidden',
+              width: `${w}px`,
+              height: `${h}px`,
+              left: `${x}px`,
+              top: `${y}px`,
+            }}
+          >
+            {element}
+          </div>
+        </TreemapContext.Provider>)
+      })}
     </>
   )
 }


### PR DESCRIPTION
Add TreemapContext to Treemap.
This allows children of Treemap to reference some information

- order
- position
- direction of next element

This allows users to customize Treemap more easily and clearly

<img width="1401" alt="Screenshot 2024-03-18 at 18 35 07" src="https://github.com/kitsuyui/react-playground/assets/2596972/86bc17db-9790-4897-8a92-443bd13ed1d5">
