### PR TITLE
Perform type checking using tsc --noEmit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: typecheck
+        run: pnpm typecheck
+
       - name: Test
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:vrt": "pnpm -r test:vrt",
     "test:vrt:install": "pnpm -r test:vrt:install",
     "test:vrt:update": "pnpm -r test:vrt:update",
+    "typecheck": "tsc --noEmit packages/*/src/**/*.ts --skipLibCheck --jsx react-jsx",
     "typedoc": "typedoc"
   },
   "devDependencies": {

--- a/packages/clock/src/digital/digital.tsx
+++ b/packages/clock/src/digital/digital.tsx
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon'
-import React from 'react'
 
 import { ClockProps } from '../types'
 import { zeroPad2 } from '../utils'

--- a/packages/clock/src/step/test.ts
+++ b/packages/clock/src/step/test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { calcHMS, sweepHMS, tickHMS } from '.'
 
 test('tickHMS returns HMS', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "target": "es2020",
+    "lib": ["esnext", "dom"],
+    "types": ["react"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -10,11 +12,10 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "types": ["react", "node"]
-  }
+    "noEmit": true
+  },
+  "exclude": ["**/test.ts", "**/*.test.ts", "**/*.spec.ts", "node_modules"]
 }


### PR DESCRIPTION
- I had a misunderstanding. I thought that if I used biome.js, it would automatically perform type checking.
- Type checking needs to be performed separately.
- For that purpose, I will use tsc --noEmit.
