### PR TITLE
Fix: Zoomer

### DIFF
--- a/packages/zoomer/src/__snapshots__/index.spec.tsx.snap
+++ b/packages/zoomer/src/__snapshots__/index.spec.tsx.snap
@@ -3,14 +3,10 @@
 exports[`Zoomer > renders without crashing 1`] = `
 <DocumentFragment>
   <div
-    style="width: 100%; height: 100%; position: absolute; overflow: clip;"
+    style="width: 100%; height: 100%; position: absolute; overflow: clip; display: flex; align-items: center; justify-content: center;"
   >
-    <div
-      style="width: fit-content; height: fit-content;"
-    >
-      <div
-        style="width: fit-content; height: fit-content;"
-      >
+    <div>
+      <div>
         Test
       </div>
     </div>
@@ -20,12 +16,8 @@ exports[`Zoomer > renders without crashing 1`] = `
 
 exports[`ZoomerWithinSize > renders without crashing 1`] = `
 <DocumentFragment>
-  <div
-    style="width: fit-content; height: fit-content;"
-  >
-    <div
-      style="width: fit-content; height: fit-content;"
-    >
+  <div>
+    <div>
       Test
     </div>
   </div>

--- a/packages/zoomer/src/index.ts
+++ b/packages/zoomer/src/index.ts
@@ -1,1 +1,1 @@
-export { Zoomer } from './zoomer'
+export { Zoomer, ZoomerWithinSize } from './zoomer'

--- a/packages/zoomer/src/stories/Example.stories.tsx
+++ b/packages/zoomer/src/stories/Example.stories.tsx
@@ -19,15 +19,7 @@ export const Default: Story = {
   decorators: [
     (Story) => {
       return (
-        <div
-          style={{
-            width: '100%',
-            height: '100%',
-            position: 'absolute',
-          }}
-        >
-          <Story />
-        </div>
+        <Story />
       )
     },
   ],
@@ -42,14 +34,14 @@ export const Default: Story = {
   },
 }
 
-export const Complex: Story = {
+export const Sized: Story = {
   args: {
     children: (
-      <div style={{ width: '300px', height: '200px', backgroundColor: 'lightblue', borderRadius: '8px' }}>
+      <div style={{ width: '300px', height: '200px', backgroundColor: 'lightblue', borderRadius: '8px'}}>
         <div style={{ fontSize: '2em', textAlign: 'center'}}>Zoomer Example</div>
         <div>
-          This is an example of the Zoomer component. It automatically adjusts the zoom level of its
-          children to fit within the specified width and height.
+          This content has a specified size. The Zoomer will adjust the zoom level while maintaining the aspect ratio.
+          The content will be put in the center of the container.
         </div>
       </div>
     )
@@ -57,15 +49,7 @@ export const Complex: Story = {
   decorators: [
     (Story) => {
       return (
-        <div
-          style={{
-            width: '100%',
-            height: '100%',
-            position: 'absolute',
-          }}
-        >
-          <Story />
-        </div>
+        <Story />
       )
     }
   ],
@@ -79,3 +63,34 @@ export const Complex: Story = {
     },
   },
 }
+
+
+export const Unsized: Story = {
+  args: {
+    children: (
+      <div style={{ backgroundColor: 'lightgreen', borderRadius: '8px' }}>
+        <div style={{ fontSize: '2em', textAlign: 'center' }}>Zoomer Example</div>
+        <div>
+          This content does not have a specified size. The Zoomer will adjust the zoom level to fit within the container.
+        </div>
+      </div>
+    )
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <Story />
+      )
+    }
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    flexDirection: 'column',
+    docs: {
+      story: {
+        inline: false,
+      },
+    },
+  },
+}
+

--- a/packages/zoomer/src/zoomer.tsx
+++ b/packages/zoomer/src/zoomer.tsx
@@ -36,6 +36,9 @@ export const Zoomer = (props: {
         height: '100%',
         position: 'absolute',
         overflow: 'clip',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
       }}
     >
       <ZoomerWithinSize
@@ -144,16 +147,10 @@ export const ZoomerWithinSize = (props: {
   return (
     <div
       ref={innerRef}
-      style={{
-        width: 'fit-content',
-        height: 'fit-content',
-      }}
     >
       <div
         style={{
           zoom: binarySearchState.zoom,
-          width: 'fit-content',
-          height: 'fit-content',
         }}
       >
         <ZoomerContext.Provider


### PR DESCRIPTION
- Fix component handle to zoom even if the children have specified size or not
  - Add story for unsized content and sized content
- export ZoomerWithinSize for convenience

<img width="881" alt="Untitled-1" src="https://github.com/user-attachments/assets/f3245c6a-6007-4ad6-b144-f3b76a219243" />
<img width="875" alt="Untitled-2" src="https://github.com/user-attachments/assets/eed19e8a-247f-4aad-8cd4-75c111c64b77" />
<img width="877" alt="Untitled-3" src="https://github.com/user-attachments/assets/e6711d56-5b9a-487f-80db-a4840e6456da" />
