### PR TITLE
Fix module resolutions

### DIFF
--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "../packages/*/src/**/*.ts",
+    "../packages/*/src/**/*.tsx"
+  ],
+  "exclude": [
+    "../packages/*/dist",
+    "../packages/*/node_modules",
+    "../packages/*/src/stories",
+    "../packages/*/src/__snapshots__", 
+    "../packages/*/src/**/*.spec.ts",
+    "../packages/*/src/**/*.spec.tsx"
+  ],
+}

--- a/.config/typedoc.js
+++ b/.config/typedoc.js
@@ -6,8 +6,10 @@ module.exports = {
   excludeProtected: true,
   excludeInternal: true,
   entryPointStrategy: 'packages',
+  tsconfig: './tsconfig.json',
   exclude: [
-    'node_modules',
+    '**/node_modules/*',
+    '**/dist/*',
     '**/*.test.ts',
     '**/*.test.tsx',
     '**/*.spec.ts',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # Extremely slow, so disabled for now ...
+      # - name: Try to build docs
+      #   run: pnpm typedoc
+
+      - name: Check package exports
+        run: pnpm validate
+
       - name: Test packaging
         run: pnpm pack
 

--- a/examples/storybook/.storybook/main.ts
+++ b/examples/storybook/.storybook/main.ts
@@ -1,6 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
+import { cjsInterop } from 'vite-plugin-cjs-interop'
 
 const config: StorybookConfig = {
   stories: [
@@ -30,6 +31,11 @@ const config: StorybookConfig = {
       ...(config.plugins || []),
       wasm(),
       topLevelAwait(),
+      cjsInterop({
+        dependencies: [
+          'react-use',
+        ],
+      }),
     ]
     config.optimizeDeps = {
       ...(config.optimizeDeps || {}),

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -15,7 +15,8 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "storybook": "^9.0.10"
+    "storybook": "^9.0.10",
+    "vite-plugin-cjs-interop": "^2.2.0"
   },
   "scripts": {
     "dev": "storybook dev -p 6006 --ci",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@storybook/addon-docs": "^9.0.10",
+    "@storybook/react-vite": "^9.0.10",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.0.3",

--- a/packages/clock/package.json
+++ b/packages/clock/package.json
@@ -4,6 +4,7 @@
   "description": "A react component to display a clock.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/dekamoji/package.json
+++ b/packages/dekamoji/package.json
@@ -4,6 +4,7 @@
   "description": "A component that displays text in the entire display area of the component.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -39,7 +40,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/measure/package.json
+++ b/packages/measure/package.json
@@ -4,6 +4,7 @@
   "description": "A react component to measure the size of a DOM node.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -38,7 +39,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/stopwatch/package.json
+++ b/packages/stopwatch/package.json
@@ -4,6 +4,7 @@
   "description": "A react component to display a stopwatch.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -39,7 +40,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -4,6 +4,7 @@
   "description": "A react component to display a timer",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -40,7 +41,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -4,6 +4,7 @@
   "description": "A react treemap component.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -27,7 +28,7 @@
     "build": "tsup --clean",
     "dev": "tsup --watch",
     "test": "vitest run",
-    "validate": "validate-package-exports --check --verify"
+    "validate": "echo 'No validation script defined. Because of this package is using WASM'"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",
@@ -39,7 +40,6 @@
   "peerDependencies": {
     "@kitsuyui/rectangle-dividing": "^0.1.4",
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/wavebox/package.json
+++ b/packages/wavebox/package.json
@@ -4,6 +4,7 @@
   "description": "A component container that shape is changing time to time.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -39,7 +40,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/zoomer/package.json
+++ b/packages/zoomer/package.json
@@ -4,6 +4,7 @@
   "description": "A component that displays text in the entire display area of the component.",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "type": "module",
   "exports": {
     ".": {
       "require": {
@@ -11,13 +12,13 @@
         "default": "./dist/index.cjs"
       },
       "import": {
-        "type": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -39,7 +40,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "react-use": "*"
+    "react-dom": "*"
   }
 }

--- a/packages/zoomer/src/zoomer.tsx
+++ b/packages/zoomer/src/zoomer.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 
 import { useMeasure } from 'react-use'
 
+// Avoid using `window` directly to ensure compatibility without browser globals. (e.g., in SSR environments)
+const window = globalThis.window || {
+  innerWidth: 2 ** 16,
+  innerHeight: 2 ** 16,
+}
 
 const EXPECT_MAX_RESOLUTION = Math.min(window.innerWidth, window.innerHeight)  // max resolution of the viewport
 const DEFAULT_MAX_ITERATIONS = Math.ceil(Math.log2(EXPECT_MAX_RESOLUTION))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@storybook/addon-docs':
         specifier: ^9.0.10
         version: 9.0.10(@types/react@19.1.8)(storybook@9.0.10(@testing-library/dom@10.4.0))
+      '@storybook/react-vite':
+        specifier: ^9.0.10
+        version: 9.0.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.43.0)(storybook@9.0.10(@testing-library/dom@10.4.0))(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(terser@5.42.0)(yaml@2.8.0))
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -138,6 +141,9 @@ importers:
       storybook:
         specifier: ^9.0.10
         version: 9.0.10(@testing-library/dom@10.4.0)
+      vite-plugin-cjs-interop:
+        specifier: ^2.2.0
+        version: 2.2.0(vite@6.3.5(@types/node@24.0.3)(terser@5.42.0)(yaml@2.8.0))
 
   packages/binary:
     devDependencies:
@@ -714,6 +720,14 @@ packages:
   '@gerrit0/mini-shiki@3.6.0':
     resolution: {integrity: sha512-KaeJvPNofTEZR9EzVNp/GQzbQqkGfjiu6k3CXKvhVTX+8OoAKSX/k7qxLKOX3B0yh2XqVAc93rsOu48CGt2Qug==}
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -834,6 +848,49 @@ packages:
   '@npmcli/run-script@9.1.0':
     resolution: {integrity: sha512-aoNSbxtkePXUlbZB+anS1LqsJdctG5n3UVhfU47+CDdwMi6uNTBMF9gPcQRnqghQd2FGzcwwIFBruFMxjhBewg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@oxc-parser/binding-darwin-arm64@0.36.0':
+    resolution: {integrity: sha512-i49m1L++ZAeAjNob5qho2ir3nflhIzgQl9hsFvmMBzG+we4OKseGlUAd/nEXJ2XnNvu1TEi/EocsE9XgWM5xlg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.36.0':
+    resolution: {integrity: sha512-+UYnDyItrh76gp7JNiTwCYyipwD1f1GkXlVkFt7L4y8GI2nMkTsvS1kUrYVsZTi33GHq4d7janrEN9HUTHqfGg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.36.0':
+    resolution: {integrity: sha512-ZZXcl9FD77EbAENTpYXCYr/zZS1Ab+qomiKIhXVRC1PXIP8qqcYpFl2NtrJHKy0ScIqNHYjzB2F9pj84howN3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.36.0':
+    resolution: {integrity: sha512-2PqTw3uiazv4vp8pGSNWDAp8DSHAxFPh3rIub5colRlu4lLGZJNXm9fgFIp0fS5Z6BFYyhnYzWNZm8bc0q2tYA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.36.0':
+    resolution: {integrity: sha512-kmRgQj/48VaBf4R9P0ccZdpgepz4F2k7nJgg5L+oPenrJhnZeD9eUzImBlN27XcpBZhDxsvj7jOTp5xSVZ7E/Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.36.0':
+    resolution: {integrity: sha512-hxpR0DdK2Zm6Gt3m/bqVLw4nZJdzkr5SsPc6sv0rPtsABx8Q6zxAf300+9mWxUm/Bf4hGHoWsCWFgWN0n87dBA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.36.0':
+    resolution: {integrity: sha512-IsarNWJhsbtARGa/7L2X2FfJt3mdQVH/CASWv99SowVaO62kLZ1lYHtU2Ps0F8dzfCwQUsWo5XnDtmfhd5nAkw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.36.0':
+    resolution: {integrity: sha512-NSlWyqWtmWA78nPWRWWzc4W6A8zY0YdX2yjbGg5PnEMiTXrW7NdVTyXdffX59ERDxtC3BT6E78e/sKS9u983pQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.36.0':
+    resolution: {integrity: sha512-VAv7ANBGE6glvOX5PEhGcca8hqBeGGDXt3xfPApZg7GhkrvbI8YCf01HojlpdIewixN2rnNpfO6cFgHS6Ixe5A==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1938,6 +1995,10 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2070,6 +2131,9 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  oxc-parser@0.36.0:
+    resolution: {integrity: sha512-dcjn+8WvWVbIO0Bb0qAJcfq8JwdkbPflYyFBg3rcDb83awlXAQLnhZuheGUxuWEh18oQFAcxkgdUdObS6DvA7A==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2677,6 +2741,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-plugin-cjs-interop@2.2.0:
+    resolution: {integrity: sha512-6r7AZMpz2kstspRiK78+4xPvK9GyiGau1uT4GOgxrdzmFFgwLTj/sF9tZiB1VyN24nHGO96wicsRoROEfPGOQg==}
+    peerDependencies:
+      vite: 4 || 5 || 6
+
   vite-plugin-top-level-await@1.5.0:
     resolution: {integrity: sha512-r/DtuvHrSqUVk23XpG2cl8gjt1aATMG5cjExXL1BUTcSNab6CzkcPua9BPEc9fuTP5UpwClCxUe3+dNGL0yrgQ==}
     peerDependencies:
@@ -3118,6 +3187,12 @@ snapshots:
       '@shikijs/types': 3.6.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3304,6 +3379,32 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  '@oxc-parser/binding-darwin-arm64@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.36.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.36.0':
+    optional: true
+
+  '@oxc-project/types@0.36.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4353,6 +4454,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -4507,6 +4612,19 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  oxc-parser@0.36.0:
+    dependencies:
+      '@oxc-project/types': 0.36.0
+    optionalDependencies:
+      '@oxc-parser/binding-darwin-arm64': 0.36.0
+      '@oxc-parser/binding-darwin-x64': 0.36.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.36.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.36.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.36.0
+      '@oxc-parser/binding-linux-x64-musl': 0.36.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.36.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.36.0
 
   p-limit@3.1.0:
     dependencies:
@@ -5186,6 +5304,14 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-cjs-interop@2.2.0(vite@6.3.5(@types/node@24.0.3)(terser@5.42.0)(yaml@2.8.0)):
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      minimatch: 10.0.3
+      oxc-parser: 0.36.0
+      vite: 6.3.5(@types/node@24.0.3)(terser@5.42.0)(yaml@2.8.0)
 
   vite-plugin-top-level-await@1.5.0(rollup@4.43.0)(vite@6.3.5(@types/node@24.0.3)(terser@5.42.0)(yaml@2.8.0)):
     dependencies:

--- a/tsup.config.mjs
+++ b/tsup.config.mjs
@@ -13,8 +13,15 @@ export default defineConfig({
     '.css': 'local-css',
   },
   sourcemap: true,
+  cjsInterop: true,
   dts: true,
   noExternal: [
     '@kitsuyui/number-time/toText',
+
+    // react-use is licensed as public domain.
+    // and it is cjs module. I waant to use it both in cjs and esm.
+    // So I bundle it.
+    // https://github.com/streamich/react-use/blob/master/LICENSE
+    'react-use',
   ],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     noExternal: [
       // workaround for testing with wasm
       '@kitsuyui/rectangle-dividing',
+
+      // react-use will be bundled (See also tsup.config.ts)
+      'react-use',
     ],
   },
   test: {


### PR DESCRIPTION
- Use `react-use` as statically bundled (not as a dependency) to avoid module resolution issues between cjs and esm.
  - `react-use` is licensed under public domain, So it is safe to bundle it statically.
  - https://github.com/streamich/react-use/blob/master/LICENSE
- Use `globalThis` instead of `window` to ensure compatibility in environments without browser globals (e.g., SSR).
- Fix all packages to use `"type": "module"` in `package.json` and ensure correct module resolutions.
  - Use `cjsInterop` in `tsup` to ensure compatibility with both ESM and CJS.
- Update CI configuration to validate package exports and build documentation.
