### PR TITLE
Set codecov coverage file

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,4 +1,0 @@
-# https://docs.codecov.com/docs
-fixes:
-  # https://docs.codecov.com/docs/fixing-paths
-  - packages/*/coverage/lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
+          files: ./coverage/coverage-final.json
           name: codecov-umbrella
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
- Currently package.json and pnpm-lock.yaml are included in the coverage report.
  - This is not intended and should be excluded.
- This change removes the .codecov.yml file and specifies the coverage file directly in the GitHub Actions workflow.
