### PR TITLE
Add gh-build-size reporting for package artifacts

### DIFF
--- a/.github/gh-build-size.yml
+++ b/.github/gh-build-size.yml
@@ -1,0 +1,24 @@
+version: 1
+publish:
+  enabled: true
+  branch: gh-build-size-assets
+comment:
+  key: package-build-size
+targets:
+  - id: total
+    label: Total package artifacts
+    files:
+      - packages/*/dist/**
+    compressions: [raw, gzip, brotli]
+    badge:
+      compression: gzip
+      label: package artifacts (gzip)
+resolvers:
+  - type: workspace-packages
+    root: packages
+    dist_dir: dist
+    include:
+      - "**/*"
+    compressions: [raw, gzip, brotli]
+    badge:
+      compression: gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -34,6 +39,12 @@ jobs:
       # Build must be run before linting and testing because some packages depends on the build output of other packages
       - name: Build
         run: bun run build
+
+      - name: Measure build size
+        if: matrix.node-version == '24.x'
+        uses: kitsuyui/gh-build-size@v0.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: bun run lint

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository also tracks `TODO` and `FIXME` markers with
 [`gh-counter`](https://github.com/kitsuyui/gh-counter). Pull requests get one
 managed comment when they touch relevant files, and the current main-branch
 count is published as a badge to the dedicated `gh-counter-assets` branch.
+It also tracks built package artifact size with
+[`gh-build-size`](https://github.com/kitsuyui/gh-build-size).
 
 # Concept
 


### PR DESCRIPTION
## Summary

- add `gh-build-size` configuration for package `dist/` outputs
- run `gh-build-size@v0.1.2` after the representative build job in CI
- mention build size tracking in the README

## Verification

- `git diff --check`
