### PR TITLE
ci: make test and release jobs blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    continue-on-error: true
-
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Remove job-level `continue-on-error` from the test workflow.
- Remove job-level `continue-on-error` from the release dry-run workflow.
- Keep the existing matrix `fail-fast: false`, so matrix jobs still run independently while failures remain visible to branch protection and PR review.

## Validation
- `ruby -e "require 'yaml'; Dir['.github/workflows/{test,release}.yml'].each { |p| YAML.load_file(p); puts "ok #{p}" }"`