### PR TITLE
Pin npm provenance workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           # https://nodejs.org/en/about/previous-releases
           node-version: '24.13.1'
@@ -40,7 +40,7 @@ jobs:
           git config user.email "dummy@dummy"
           git config user.name "dummy"
           # dummy tag for dry-run
-          git tag v0.0.0-rc.$GITHUB_RUN_NUMBER
+          git tag "v0.0.0-rc.${GITHUB_RUN_NUMBER}"
 
       - name: set git tag version
         run: |


### PR DESCRIPTION
## Summary

- Pin the npm provenance release workflow actions to their current commit SHAs.
- Quote the pull request dummy tag argument so `actionlint`/ShellCheck can validate the workflow cleanly.
- Keep release triggers, permissions, build/validation commands, and npm publish conditions unchanged.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `actionlint .github/workflows/release.yml`
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run validate`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Publish and dry-run publish steps were not run locally.
