### PR TITLE
Pin octocov workflow actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.13.1
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary
- Pin the Octocov workflow actions to full commit SHAs
- Keep the original major-version tags as inline comments for update context

## Verification
- actionlint .github/workflows/octocov.yml
- git diff --check
- bun install --frozen-lockfile
- bun run lint
- bun run test
