### PR TITLE
Bump @chenglou/pretext from ^0.0.3 to ^0.0.5 (GHSA-5478-66c3-rhxr)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
       "name": "@kitsuyui/react-dekamoji",
       "version": "0.0.0",
       "dependencies": {
-        "@chenglou/pretext": "^0.0.3",
+        "@chenglou/pretext": "^0.0.5",
       },
       "devDependencies": {
         "@types/node": "^25.3.0",
@@ -367,7 +367,7 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
-    "@chenglou/pretext": ["@chenglou/pretext@0.0.3", "", {}, "sha512-RQmqMqUAPRCyv4R3LlRi/ao6KbNWYclqLA+V1HS7sWgyUUbjn3JmmlfXZSY/BjM4rbmIaMSyIVisYocYGYftiQ=="],
+    "@chenglou/pretext": ["@chenglou/pretext@0.0.5", "", {}, "sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 

--- a/packages/dekamoji/package.json
+++ b/packages/dekamoji/package.json
@@ -34,7 +34,7 @@
     "validate": "validate-package-exports --check"
   },
   "dependencies": {
-    "@chenglou/pretext": "^0.0.3"
+    "@chenglou/pretext": "^0.0.5"
   },
   "devDependencies": {
     "@types/node": "^25.3.0",


### PR DESCRIPTION
## Summary

- Bumps `@chenglou/pretext` in `packages/dekamoji` from `^0.0.3` to `^0.0.5`.
- Resolves Dependabot alert [#85](https://github.com/kitsuyui/react-playground/security/dependabot/85) — high-severity DoS [GHSA-5478-66c3-rhxr](https://github.com/advisories/GHSA-5478-66c3-rhxr) (Pretext: Algorithmic Complexity in text analysis phase).

## Why

`isRepeatedSingleCharRun()` in pretext `<= 0.0.4` re-scanned the entire accumulated segment on every merge iteration during text analysis, yielding O(n²) total work for inputs like `"(".repeat(80_000)`. The patched `0.0.5` replaces the full scan with an O(1) endpoint check.

`@chenglou/pretext` is consumed only by `packages/dekamoji` (via `prepare()`), so the blast radius of the bump is limited to that package.

## Test plan

- [x] `bun install` regenerated `bun.lock` cleanly (entry now resolves to `0.0.5`).
- [x] `bun run lint` passes.
- [x] `cd packages/dekamoji && bun run build` succeeds.
- [x] `cd packages/dekamoji && bun run test` passes (2/2).