### PR TITLE
Pin remaining workflow actions to commit SHA

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -12,13 +12,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # https://nodejs.org/en/about/previous-releases
           node-version: 24.13.1
@@ -34,7 +34,7 @@ jobs:
           mv ./examples/storybook/storybook-static ./build/sites/storybook
           mv ./build/typedocs ./build/sites/typedocs
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         id: deployment
         with:
           path: ./build/sites
@@ -54,4 +54,4 @@ jobs:
       # https://github.com/actions/deploy-pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@0b691527a4dde052c79eae22706131a7726a2bba # main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,16 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
 
       - name: Measure build size
         if: matrix.node-version == '24.x'
-        uses: kitsuyui/gh-build-size@v0.1.2
+        uses: kitsuyui/gh-build-size@97ad8d5f4fff8ba676a5c614822adacab32780e3 # v0.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Pin external `uses:` references in `build_docs.yml`, `spellcheck.yml`, and `test.yml` to 40-character commit SHAs.
- `actions/checkout`, `oven-sh/setup-bun`, and `actions/setup-node` reuse the SHAs already pinned in `.github/workflows/octocov.yml` / `release.yml`.
- `actions/upload-pages-artifact@v4`, `actions/deploy-pages@v4`, and `kitsuyui/gh-build-size@v0.1.2` are pinned to the SHA each tag currently points at.
- `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml` is pinned to `0b691527a4dde052c79eae22706131a7726a2bba`, matching the SHA used by `gh-counter.yml`, `gitignore-in.yml`, and `happy.yml` so Renovate can bump consumers together.

## Why

External action tags can be moved upstream, so they are not a stable CI/CD supply-chain input for a public repo. Pinning to a commit SHA fixes the input and the tag annotation preserves the human-readable version. The pattern matches `48b266d` (Pin octocov workflow actions) and `81d6234` (Pin reusable workflow references) on the same repo.

## Test plan

- [ ] `test` workflow passes on this PR
- [ ] `Spellcheck` workflow passes on this PR
- [ ] `build_docs` and Pages deploy run after merge to `main`