### PR TITLE
fix(textfield): use Object.assign for useImperativeHandle to preserve DOM prototype methods

### DIFF
--- a/packages/textfield/src/TextArea.tsx
+++ b/packages/textfield/src/TextArea.tsx
@@ -31,7 +31,7 @@ export const TextArea = (props: TextAreaProps) => {
   const [internalValue, setInternalValue] = React.useState(props.value ?? '')
   const [isInputting, setIsInputting] = React.useState(false)
   const innerRef = React.useRef<HTMLTextAreaElement>(null)
-  const compbinedRef = useCombinedRefs(innerRef, ref)
+  const combinedRef = useCombinedRefs(innerRef, ref)
 
   React.useImperativeHandle(ref, () => {
     const current = innerRef?.current as HTMLTextAreaElement
@@ -42,10 +42,7 @@ export const TextArea = (props: TextAreaProps) => {
         onInputChunk?.('')
       }
     }
-    return {
-      ...current,
-      ...extra
-    }
+    return Object.assign(current, extra)
   })
 
   // Use Object.assign({}, props) instead of just { ...props } because it must create deep copy.
@@ -94,7 +91,7 @@ export const TextArea = (props: TextAreaProps) => {
   return (
     <textarea
       {...propsExcludedWrapperProps}
-      ref={compbinedRef}
+      ref={combinedRef}
       value={internalValue}
       onCompositionStart={handleCompositionChange}
       onCompositionUpdate={handleCompositionChange}

--- a/packages/textfield/src/TextField.tsx
+++ b/packages/textfield/src/TextField.tsx
@@ -43,10 +43,7 @@ export const TextField = (props: TextFieldProps) => {
         onInputChunk?.('')
       }
     }
-    return {
-      ...current,
-      ...extra
-    }
+    return Object.assign(current, extra)
   })
 
   // Use Object.assign({}, props) instead of just { ...props } because it must create deep copy.


### PR DESCRIPTION
## Summary

`useImperativeHandle` in `TextField` and `TextArea` used `{ ...current, ...extra }` to build the handle, where `current` is an `HTMLInputElement` / `HTMLTextAreaElement`. Object spread only copies own enumerable properties, so prototype methods like `focus()`, `blur()`, and `select()` were lost from the exposed ref.

Calling `ref.current.focus()` would throw `TypeError: not a function` at runtime despite the TypeScript types allowing it.

## Changes

- Replace `{ ...current, ...extra }` with `Object.assign(current, extra)` in both `TextField.tsx` and `TextArea.tsx` — returns the actual DOM element with the `clear()` method attached, preserving the full prototype chain.
- Fix typo: `compbinedRef` → `combinedRef` in `TextArea.tsx`.

## Verification

- All 129 unit tests pass (`bun run test`).
- TypeScript type check passes (`bun run typecheck`).
- Biome lint passes (`bun run lint`).