### PR TITLE
fix(textfield/timer): fix useMemo deps, useImperativeHandle spread, and duplicate onComplete

### DIFF
--- a/packages/textfield/src/TextArea.tsx
+++ b/packages/textfield/src/TextArea.tsx
@@ -31,7 +31,7 @@ export const TextArea = (props: TextAreaProps) => {
   const [internalValue, setInternalValue] = React.useState(props.value ?? '')
   const [isInputting, setIsInputting] = React.useState(false)
   const innerRef = React.useRef<HTMLTextAreaElement>(null)
-  const compbinedRef = useCombinedRefs(innerRef, ref)
+  const combinedRef = useCombinedRefs(innerRef, ref)
 
   React.useImperativeHandle(ref, () => {
     const current = innerRef?.current as HTMLTextAreaElement
@@ -42,10 +42,7 @@ export const TextArea = (props: TextAreaProps) => {
         onInputChunk?.('')
       }
     }
-    return {
-      ...current,
-      ...extra
-    }
+    return Object.assign(current, extra)
   })
 
   // Use Object.assign({}, props) instead of just { ...props } because it must create deep copy.
@@ -94,7 +91,7 @@ export const TextArea = (props: TextAreaProps) => {
   return (
     <textarea
       {...propsExcludedWrapperProps}
-      ref={compbinedRef}
+      ref={combinedRef}
       value={internalValue}
       onCompositionStart={handleCompositionChange}
       onCompositionUpdate={handleCompositionChange}

--- a/packages/textfield/src/TextField.tsx
+++ b/packages/textfield/src/TextField.tsx
@@ -43,10 +43,7 @@ export const TextField = (props: TextFieldProps) => {
         onInputChunk?.('')
       }
     }
-    return {
-      ...current,
-      ...extra
-    }
+    return Object.assign(current, extra)
   })
 
   // Use Object.assign({}, props) instead of just { ...props } because it must create deep copy.

--- a/packages/textfield/src/utils/refs.ts
+++ b/packages/textfield/src/utils/refs.ts
@@ -14,10 +14,11 @@ type Cleanup = (() => void) | undefined
  * @returns combined ref
  */
 export const useCombinedRefs = <T>(...refs: OptionalRef<T>[]) => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refs is a rest parameter; spreading its elements as deps is the correct fix for the new-array-every-render problem
   return useMemo(() => {
     if (!hasAnyRef(refs)) return null
     return (node: T) => assignNodeToRefs(refs, node)
-  }, [refs])
+  }, [...refs])
 }
 
 const hasAnyRef = <T>(refs: OptionalRef<T>[]) => {

--- a/packages/timer/src/context.spec.tsx
+++ b/packages/timer/src/context.spec.tsx
@@ -1,14 +1,11 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-import { render } from '@testing-library/react'
-
-import { act } from '@testing-library/react'
 import {
   TimerContext,
   TimerContextProvider,
   type TimerContextValue,
 } from './context'
-import React from 'react'
 
 describe('TimerContextProvider', () => {
   let restoreNavigatorVibrate = () => {}
@@ -36,6 +33,29 @@ describe('TimerContextProvider', () => {
     )
     vi.advanceTimersByTime(10) // refresh interval
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('calls onComplete exactly once even when many intervals fire after expiry', async () => {
+    const onComplete = vi.fn()
+    const { getContext } = renderTimerContext({
+      refreshInterval: 10,
+      onComplete,
+    })
+
+    act(() => {
+      getContext().setTimerValue(1)
+    })
+    act(() => {
+      getContext().start()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+
+    expect(getContext().running).toBe(false)
+    expect(getContext().remaining).toBe(0)
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
   it('supports timer actions and completion side effects', async () => {
@@ -132,7 +152,9 @@ const renderTimerContext = (
   }
 }
 
-const stubNavigatorVibrate = (vibrate: (pattern: number | number[]) => boolean) => {
+const stubNavigatorVibrate = (
+  vibrate: (pattern: number | number[]) => boolean
+) => {
   const originalVibrate = Object.getOwnPropertyDescriptor(navigator, 'vibrate')
   Object.defineProperty(navigator, 'vibrate', {
     configurable: true,

--- a/packages/timer/src/context.tsx
+++ b/packages/timer/src/context.tsx
@@ -29,14 +29,30 @@ export const TimerContext = React.createContext<TimerContextValue>({
   running: false,
   vibrationEnabled: false,
   vibrationSupported: false,
-  start: () => { /* do nothing */ },
-  stop: () => { /* do nothing */ },
-  toggle: () => { /* do nothing */ },
-  reset: () => { /* do nothing */ },
-  incrementTimerValue: (_value: number) => { /* do nothing */ },
-  setTimerValue: (_value: number) => { /* do nothing */ },
-  setVibrationEnabled: (_value: boolean) => { /* do nothing */ },
-  toggleVibration: () => { /* do nothing */ },
+  start: () => {
+    /* do nothing */
+  },
+  stop: () => {
+    /* do nothing */
+  },
+  toggle: () => {
+    /* do nothing */
+  },
+  reset: () => {
+    /* do nothing */
+  },
+  incrementTimerValue: (_value: number) => {
+    /* do nothing */
+  },
+  setTimerValue: (_value: number) => {
+    /* do nothing */
+  },
+  setVibrationEnabled: (_value: boolean) => {
+    /* do nothing */
+  },
+  toggleVibration: () => {
+    /* do nothing */
+  },
 })
 
 export interface TimerContextProviderProps {
@@ -95,28 +111,32 @@ const notifyTimerCompletion = (
 }
 
 const completeTimer = (props: {
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setRunning: React.Dispatch<React.SetStateAction<boolean>>
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   notifyCompletion: () => void
 }) => {
+  props.runningRef.current = false
+  props.targetTimeMsRef.current = null
   props.setRemaining(0)
   props.setRunning(false)
-  props.setTargetTimeMs(null)
+  props.setTargetTimeMsState(null)
   props.notifyCompletion()
 }
 
 const createTimerTick = (props: {
-  running: boolean
-  targetTimeMs: number | null
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
   getCurrentRemaining: (nowMs?: number) => number
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setRunning: React.Dispatch<React.SetStateAction<boolean>>
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   notifyCompletion: () => void
 }) => {
   return () => {
-    if (shouldSkipTimerTick(props.running, props.targetTimeMs)) return
+    if (shouldSkipTimerTick(props.runningRef, props.targetTimeMsRef)) return
     const nextRemaining = props.getCurrentRemaining()
     props.setRemaining(nextRemaining)
     handleTimerCompletion(nextRemaining, props)
@@ -124,18 +144,20 @@ const createTimerTick = (props: {
 }
 
 const shouldSkipTimerTick = (
-  running: boolean,
-  targetTimeMs: number | null
+  runningRef: React.MutableRefObject<boolean>,
+  targetTimeMsRef: React.MutableRefObject<number | null>
 ) => {
-  return !running || targetTimeMs === null
+  return !runningRef.current || targetTimeMsRef.current === null
 }
 
 const handleTimerCompletion = (
   nextRemaining: number,
   props: {
+    runningRef: React.MutableRefObject<boolean>
+    targetTimeMsRef: React.MutableRefObject<number | null>
     setRemaining: React.Dispatch<React.SetStateAction<number>>
     setRunning: React.Dispatch<React.SetStateAction<boolean>>
-    setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+    setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
     notifyCompletion: () => void
   }
 ) => {
@@ -145,33 +167,40 @@ const handleTimerCompletion = (
 
 const createTimerStart = (props: {
   remaining: number
-  running: boolean
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   setRunning: React.Dispatch<React.SetStateAction<boolean>>
   onStart: TimerEventHandler
 }) => {
   return () => {
-    if (props.remaining <= 0 || props.running) return
+    if (props.remaining <= 0 || props.runningRef.current) return
     const nowMs = Date.now()
-    props.setTargetTimeMs(nowMs + props.remaining * 1000)
+    const nextTargetTimeMs = nowMs + props.remaining * 1000
+    props.targetTimeMsRef.current = nextTargetTimeMs
+    props.runningRef.current = true
+    props.setTargetTimeMsState(nextTargetTimeMs)
     props.setRunning(true)
     props.onStart(new CustomEvent('start', {}))
   }
 }
 
 const createTimerStop = (props: {
-  running: boolean
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
   getCurrentRemaining: (nowMs?: number) => number
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setRunning: React.Dispatch<React.SetStateAction<boolean>>
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   onStop: TimerEventHandler
 }) => {
   return () => {
-    if (!props.running) return
+    if (!props.runningRef.current) return
     props.setRemaining(props.getCurrentRemaining())
+    props.runningRef.current = false
+    props.targetTimeMsRef.current = null
     props.setRunning(false)
-    props.setTargetTimeMs(null)
+    props.setTargetTimeMsState(null)
     props.onStop(new CustomEvent('stop', {}))
   }
 }
@@ -191,13 +220,17 @@ const createTimerToggle = (
 }
 
 const createSetTimerValue = (
+  runningRef: React.MutableRefObject<boolean>,
+  targetTimeMsRef: React.MutableRefObject<number | null>,
   setRunning: React.Dispatch<React.SetStateAction<boolean>>,
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>,
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>,
   setRemaining: React.Dispatch<React.SetStateAction<number>>
 ) => {
   return (value: number) => {
+    runningRef.current = false
+    targetTimeMsRef.current = null
     setRunning(false)
-    setTargetTimeMs(null)
+    setTargetTimeMsState(null)
     setRemaining(Math.max(0, value || 0))
   }
 }
@@ -219,59 +252,80 @@ const createToggleVibrationAction = (
 }
 
 const createIncrementTimerValue = (props: {
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
   getCurrentRemaining: (nowMs?: number) => number
   setRunning: React.Dispatch<React.SetStateAction<boolean>>
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
 }) => {
   return (value: number) => {
     const baseRemaining = props.getCurrentRemaining()
+    props.runningRef.current = false
+    props.targetTimeMsRef.current = null
     props.setRunning(false)
-    props.setTargetTimeMs(null)
+    props.setTargetTimeMsState(null)
     props.setRemaining(Math.max(0, baseRemaining + value))
   }
 }
 
-const createResetTimer = (
-  setRunning: React.Dispatch<React.SetStateAction<boolean>>,
-  setTargetTimeMs: React.Dispatch<React.SetStateAction<number | null>>,
-  setRemaining: React.Dispatch<React.SetStateAction<number>>,
+const createResetTimer = (props: {
+  runningRef: React.MutableRefObject<boolean>
+  targetTimeMsRef: React.MutableRefObject<number | null>
+  setRunning: React.Dispatch<React.SetStateAction<boolean>>
+  setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
+  setRemaining: React.Dispatch<React.SetStateAction<number>>
   onReset: TimerEventHandler
-) => {
+}) => {
   return () => {
-    setRunning(false)
-    setTargetTimeMs(null)
-    setRemaining(0)
-    onReset(new CustomEvent('reset', {}))
+    props.runningRef.current = false
+    props.targetTimeMsRef.current = null
+    props.setRunning(false)
+    props.setTargetTimeMsState(null)
+    props.setRemaining(0)
+    props.onReset(new CustomEvent('reset', {}))
   }
 }
 
 const calculateElapsedVibrationSupported = () => {
-  return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+  return (
+    typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+  )
 }
 
 export const TimerContextProvider: React.FC<TimerContextProviderProps> = (
   props
 ): React.JSX.Element => {
   const { children } = props
-  const emptyFn = (_event: CustomEvent) => { /* do nothing */ }
+  const emptyFn = (_event: CustomEvent) => {
+    /* do nothing */
+  }
   const onStart = resolveHandler(props.onStart, emptyFn)
   const onStop = resolveHandler(props.onStop, emptyFn)
   const onComplete = resolveHandler(props.onComplete, emptyFn)
   const onReset = resolveHandler(props.onReset, emptyFn)
   const [running, setRunning] = React.useState(false)
   const [remaining, setRemaining] = React.useState(0)
-  const [targetTimeMs, setTargetTimeMs] = React.useState<number | null>(null)
+  const [targetTimeMs, setTargetTimeMsState] = React.useState<number | null>(
+    null
+  )
   const [vibrationEnabled, setVibrationEnabled] = React.useState(
     resolveDefaultVibrationEnabled(props.defaultVibrationEnabled)
   )
+  const runningRef = React.useRef(running)
+  const targetTimeMsRef = React.useRef<number | null>(targetTimeMs)
   const vibrationPattern = resolveVibrationPattern(props.vibrationPattern)
   const vibrationSupported = calculateElapsedVibrationSupported()
 
   const refreshInterval = resolveTimerRefreshInterval(props.refreshInterval)
 
   const getCurrentRemaining = (nowMs = Date.now()) =>
-    getTimerCurrentRemaining(running, targetTimeMs, remaining, nowMs)
+    getTimerCurrentRemaining(
+      runningRef.current,
+      targetTimeMsRef.current,
+      remaining,
+      nowMs
+    )
 
   const notifyCompletion = () =>
     notifyTimerCompletion(
@@ -282,12 +336,12 @@ export const TimerContextProvider: React.FC<TimerContextProviderProps> = (
     )
 
   const tick = createTimerTick({
-    running,
-    targetTimeMs,
+    runningRef,
+    targetTimeMsRef,
     getCurrentRemaining,
     setRemaining,
     setRunning,
-    setTargetTimeMs,
+    setTargetTimeMsState,
     notifyCompletion,
   })
 
@@ -295,32 +349,45 @@ export const TimerContextProvider: React.FC<TimerContextProviderProps> = (
 
   const start = createTimerStart({
     remaining,
-    running,
-    setTargetTimeMs,
+    runningRef,
+    targetTimeMsRef,
+    setTargetTimeMsState,
     setRunning,
     onStart,
   })
 
   const stop = createTimerStop({
-    running,
+    runningRef,
+    targetTimeMsRef,
     getCurrentRemaining,
     setRemaining,
     setRunning,
-    setTargetTimeMs,
+    setTargetTimeMsState,
     onStop,
   })
 
   const toggle = createTimerToggle(running, start, stop)
-  const reset = createResetTimer(setRunning, setTargetTimeMs, setRemaining, onReset)
-  const setTimerValue = createSetTimerValue(
+  const reset = createResetTimer({
+    runningRef,
+    targetTimeMsRef,
     setRunning,
-    setTargetTimeMs,
+    setTargetTimeMsState,
+    setRemaining,
+    onReset,
+  })
+  const setTimerValue = createSetTimerValue(
+    runningRef,
+    targetTimeMsRef,
+    setRunning,
+    setTargetTimeMsState,
     setRemaining
   )
   const incrementTimerValue = createIncrementTimerValue({
+    runningRef,
+    targetTimeMsRef,
     getCurrentRemaining,
     setRunning,
-    setTargetTimeMs,
+    setTargetTimeMsState,
     setRemaining,
   })
   const setVibrationEnabledAction =


### PR DESCRIPTION
## Summary

Three React correctness fixes in the `textfield` and `timer` packages.

### 1. `useCombinedRefs`: fix `useMemo` always recomputing

`useCombinedRefs` accepted rest parameters and passed `refs` (the array) directly as the `useMemo` dependency. Because rest parameters create a new array on every call, the shallow-equal check always failed and `useMemo` never cached anything — generating a new ref callback every render and causing unintended ref detach/reattach cycles on `TextField` and `TextArea`.

**Fix**: spread individual refs as deps (`[...refs]`) so React compares each ref value rather than the ever-new array container.

### 2. `useImperativeHandle`: use `Object.assign` instead of spread

The object spread `{ ...current, ...extra }` in `useImperativeHandle` returns a plain object, losing the DOM element's prototype chain. Consumers that expect an `HTMLInputElement` or `HTMLTextAreaElement` instance will break with a plain object. `Object.assign(current, extra)` mutates the element in-place, preserving the prototype.

### 3. Timer: prevent duplicate `onComplete` calls

When many ticks fire in rapid succession around the completion moment (e.g. fast `refreshInterval`), the timer could call `onComplete` more than once because state updates are batched asynchronously and `running`/`targetTimeMs` read stale values. Introduced `useRef` guards (`runningRef`, `targetTimeMsRef`) that are updated synchronously before dispatching state, so the tick sees up-to-date values and the completion callback fires exactly once.

## Verification

- All 130 tests pass (`bun run test`)
- Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
- New test added for the duplicate-completion scenario
