### PR TITLE
fix(wavebox): throw RangeError when curve() cycle is zero or negative

### DIFF
--- a/packages/wavebox/src/curve.spec.ts
+++ b/packages/wavebox/src/curve.spec.ts
@@ -18,4 +18,14 @@ describe('curve', () => {
     const result4 = curve(minValue, maxValue, cycle, cycle)
     expect(result4).toBeCloseTo(5, 5) // At t=cycle, the sine wave should be at its midpoint again
   })
+
+  it('should throw RangeError when cycle is zero', () => {
+    expect(() => curve(0, 10, 0, 1)).toThrow(RangeError)
+    expect(() => curve(0, 10, 0, 1)).toThrow('cycle must be a positive number, got 0')
+  })
+
+  it('should throw RangeError when cycle is negative', () => {
+    expect(() => curve(0, 10, -1, 1)).toThrow(RangeError)
+    expect(() => curve(0, 10, -100, 5)).toThrow('cycle must be a positive number, got -100')
+  })
 })

--- a/packages/wavebox/src/curve.ts
+++ b/packages/wavebox/src/curve.ts
@@ -7,6 +7,9 @@ export const curve = (
   cycle: number,
   tick: number
 ): number => {
+  if (cycle <= 0) {
+    throw new RangeError(`cycle must be a positive number, got ${cycle}`)
+  }
   const amplitude = (maxValue - minValue) / 2
   return Math.sin(2 * Math.PI * tick / cycle) * amplitude + amplitude + minValue
 }


### PR DESCRIPTION
## Summary

`curve()` in `packages/wavebox/src/curve.ts` had no guard against `cycle <= 0`. When `cycle=0`, the expression `2 * Math.PI * tick / 0` evaluates to `Infinity` for any non-zero tick, and `Math.sin(Infinity)` returns `NaN`. This `NaN` propagated to the CSS `width`/`height` of `BaseWaveBox`, silently breaking layout without any error signal.

## Changes

- **`packages/wavebox/src/curve.ts`**: Add `RangeError` guard at the top of `curve()` for `cycle <= 0`.
- **`packages/wavebox/src/curve.spec.ts`**: Add tests for `cycle=0` and `cycle<0` edge cases.

## Verification

- All 131 existing tests pass (`bun run test` — 45 test files).
- Biome lint: no issues.
- TypeScript typecheck: no errors.
- Module isolation check: no circular dependencies.

## Trade-offs

Throwing `RangeError` makes invalid input explicit and debuggable at call time. The alternative of returning a silent fallback (e.g., `minValue`) would allow callers to pass zero and receive a plausible-looking value, hiding the bug.
