### PR TITLE
fix(biticon): document little-endian bit order in from128bitTo2bitArray

### DIFF
--- a/packages/biticon/src/bits.spec.ts
+++ b/packages/biticon/src/bits.spec.ts
@@ -17,6 +17,20 @@ describe('from128bitTo2bitArray', () => {
       expect(output[i]).satisfies((value: number) => value >= 0 && value <= 3)
     }
   })
+
+  it('uses little-endian bit order: bytes[0] holds the least significant 2 bits', () => {
+    // 0b01 in the LSB position → bytes[0] == 1
+    expect(from128bitTo2bitArray(BigInt(0b01))[0]).toBe(1)
+    // 0b10 in the LSB position → bytes[0] == 2
+    expect(from128bitTo2bitArray(BigInt(0b10))[0]).toBe(2)
+    // 0b11 at bits [127:126] (MSB) → bytes[63] == 3, all others == 0
+    const msb = BigInt('0b11') << BigInt(126)
+    const arr = from128bitTo2bitArray(msb)
+    expect(arr[63]).toBe(3)
+    expect(arr[62]).toBe(0)
+    expect(arr[0]).toBe(0)
+  })
+
   it('is inversible to from2bitArrayTo128bit', () => {
     const input = BigInt('0xfedcba9876543210fedcba9876543210')
     expect(input.toString(2).length).toBe(128)

--- a/packages/biticon/src/bits.ts
+++ b/packages/biticon/src/bits.ts
@@ -3,18 +3,23 @@ export const is128Bit = (value: bigint): boolean => {
 }
 
 /**
- * Convert 128bit value to int8 array
+ * Convert 128bit value to int8 array in little-endian bit order.
+ *
+ * The array is ordered with the least significant bits first:
+ * - bytes[0]  = bits [1:0]   (least significant 2 bits)
+ * - bytes[63] = bits [127:126] (most significant 2 bits)
+ *
+ * This is the inverse of {@link from2bitArrayTo128bit}.
+ *
  * @param value 128bit value
- * @returns Uint8Array but each element is 2 bits (0-3) and the array has 64 elements (2 * 64 = 128 bits)
+ * @returns Uint8Array with 64 elements, each holding a 2-bit value (0-3)
  */
 export const from128bitTo2bitArray = (value: bigint): Uint8Array => {
-  // FIXME: There might be bugs related to endianness... (first character will be the last in the array)
   const mask = BigInt(0b11) // 2 bits (0b00, 0b01, 0b10, 0b11)
   const bytes = new Uint8Array(64)
   for (let i = 0; i < 64; i++) {
-    // take 2 bits from the value
     const bit = BigInt(i) * BigInt(2)
-    const value_ = (value >> bit ) & mask  // shift the value to the right by 2 bits for each iteration
+    const value_ = (value >> bit) & mask
     bytes[i] = Number(value_)
   }
   return bytes


### PR DESCRIPTION
## Summary

Remove the `FIXME` comment from `from128bitTo2bitArray()` in `packages/biticon/src/bits.ts` and replace it with explicit documentation of the intended little-endian bit ordering.

## Background

The function extracts 2-bit groups starting from the least significant bits (bytes[0] = bits[1:0], bytes[63] = bits[127:126]). This LSB-first ordering is consistent with its inverse `from2bitArrayTo128bit()`, which reconstructs the original value correctly. The FIXME comment ("first character will be the last in the array") was accurate but left the intended behavior undocumented, making it ambiguous whether the ordering was a bug or a design choice.

## Changes

- **`packages/biticon/src/bits.ts`**: Replace FIXME with a docstring section explaining the little-endian bit order and reference to the inverse function.
- **`packages/biticon/src/bits.spec.ts`**: Add a test that explicitly verifies `bytes[0]` holds the least significant 2 bits and `bytes[63]` holds the most significant 2 bits.

## Verification

- All 130 tests pass (`bun run test` — 45 test files, no regressions).
- Biome lint: no issues.
- TypeScript typecheck: no errors.
- No behavior changes — only documentation and a new regression test.

## Trade-offs

Documenting the current (little-endian) behavior rather than reversing it avoids a breaking change to the visual output of all existing `BitIcon` instances. If a different ordering is needed in the future, it can be introduced with a new function or a parameter.
