### PR TITLE
fix: accept uppercase hex digits in isValidUUID

### DIFF
--- a/packages/biticon/src/uuid.spec.ts
+++ b/packages/biticon/src/uuid.spec.ts
@@ -8,6 +8,9 @@ describe('isValidUUID', () => {
       '123e4567-e89b-12d3-a456-426614174000',
       '550e8400-e29b-41d4-a716-446655440000',
       '00000000-0000-0000-0000-000000000000',
+      // RFC 4122 §3 allows uppercase hex digits
+      '550E8400-E29B-41D4-A716-446655440000',
+      '123E4567-E89B-12D3-A456-426614174000',
     ]
     for (const uuid of validUUIDs) {
       expect(isValidUUID(uuid)).toBe(true)

--- a/packages/biticon/src/uuid.ts
+++ b/packages/biticon/src/uuid.ts
@@ -1,5 +1,5 @@
 export const isValidUUID = (uuid: string): boolean => {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(uuid)
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uuid)
 }
 
 export const uuidToBigInt = (uuid: string): bigint => {


### PR DESCRIPTION
## Summary

`isValidUUID()` in `packages/biticon/src/uuid.ts` only accepted lowercase hex digits, rejecting valid uppercase UUIDs such as those generated by Windows Active Directory, Java, and many databases.

RFC 4122 §3 explicitly permits both uppercase and lowercase hex digits in UUID representation.

## Changes

- `packages/biticon/src/uuid.ts`: Add the `i` (case-insensitive) flag to the UUID validation regex
- `packages/biticon/src/uuid.spec.ts`: Add test cases for uppercase UUIDs to prevent regression

## Verification

- All 45 test files pass (`bun run test`)
- Lint clean (`bun run lint`)
- Typecheck clean (`bun run typecheck`)