### PR TITLE
test(biticon): add component and color specs

### DIFF
--- a/packages/biticon/src/BitIcon.spec.tsx
+++ b/packages/biticon/src/BitIcon.spec.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { BitIcon } from './BitIcon'
+import { COLORS } from './colors'
+
+const firstFourColorsBits = BigInt('0xe4')
+const outOfRange128BitValue = BigInt('0x100000000000000000000000000000000')
+
+describe('BitIcon', () => {
+  test('renders a valid 128-bit value as an accessible SVG', () => {
+    const { container } = render(<BitIcon bits={firstFourColorsBits} />)
+    const svg = container.querySelector('svg')
+    const rects = container.querySelectorAll('rect')
+
+    expect(svg?.getAttribute('role')).toBe('img')
+    expect(svg?.getAttribute('aria-label')).toMatch(/^BitIcon: 0123/)
+    expect(rects).toHaveLength(64)
+
+    for (const [index, color] of COLORS.entries()) {
+      expect(rects[index]?.getAttribute('fill')).toBe(color)
+    }
+  })
+
+  test('passes svg props through to the rendered icon', () => {
+    const { container } = render(
+      <BitIcon
+        bits={firstFourColorsBits}
+        width="1em"
+        height="1em"
+        className="icon"
+      />
+    )
+    const svg = container.querySelector('svg')
+
+    expect(svg?.getAttribute('width')).toBe('1em')
+    expect(svg?.getAttribute('height')).toBe('1em')
+    expect(svg?.getAttribute('class')).toBe('icon')
+  })
+
+  test('renders error message with invalid bits', () => {
+    const { container } = render(<BitIcon bits={outOfRange128BitValue} />)
+
+    expect(container.querySelector('svg')).toBeNull()
+    expect(container.textContent).toBe('Invalid 128bit value')
+  })
+})

--- a/packages/biticon/src/colors.spec.ts
+++ b/packages/biticon/src/colors.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { COLORS, valueToColor } from './colors'
+
+describe('valueToColor', () => {
+  it.each([
+    [0, '#440154'],
+    [1, '#30678d'],
+    [2, '#35b778'],
+    [3, '#fde724'],
+  ])('maps 2-bit value %i to %s', (value, color) => {
+    expect(valueToColor(value)).toBe(color)
+  })
+
+  it('has one palette entry for each 2-bit value', () => {
+    expect(COLORS).toHaveLength(4)
+  })
+})

--- a/packages/biticon/src/colors.ts
+++ b/packages/biticon/src/colors.ts
@@ -10,8 +10,8 @@ export const COLORS = [
 
 /**
  * Convert value to color
- * @param value 0-7
- * @returns color string
+ * @param value 0-3
+ * @returns color string for a 2-bit value
  */
 export const valueToColor = (value: number): string => {
   return COLORS[value]


### PR DESCRIPTION
## Summary
- Add coverage for `BitIcon` rendering, SVG prop pass-through, palette fills, and invalid 128-bit input handling.
- Add `valueToColor` palette coverage for the supported 2-bit values.
- Correct the `valueToColor` JSDoc range to match the 2-bit palette.

## Validation
- `bun install --frozen-lockfile`
- `bunx vitest run packages/biticon/src/BitIcon.spec.tsx packages/biticon/src/colors.spec.ts`
- `bun run format`
- `actionlint`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run test`
- `bun run validate`
- `bun run typedoc`
- package dry-run loop: `bun pm pack --dry-run` for non-private packages
- `bunx madge --extensions ts,tsx --circular packages/biticon/src`
- `git diff --check`
