### PR TITLE
Bound tick counter in WaveBoxProvider to prevent integer overflow

### DIFF
--- a/packages/wavebox/src/wavebox.tsx
+++ b/packages/wavebox/src/wavebox.tsx
@@ -95,7 +95,7 @@ export const WaveBoxProvider = (props: {
   const interval = props.interval ?? DEFAULT_INTERVAL
   const [tick, setTick] = React.useState<number>(0)
   useInterval(() => {
-    setTick((prevTick) => prevTick + 1)
+    setTick((prevTick) => (prevTick + 1) % Number.MAX_SAFE_INTEGER)
   }, interval)
   return (
     <WaveBoxContext


### PR DESCRIPTION
## Summary

The `tick` counter in `WaveBoxProvider` incremented without an upper bound. Over very long runtimes, the counter could exceed `Number.MAX_SAFE_INTEGER` (2^53 − 1), at which point JavaScript's floating-point representation loses integer precision. The resulting imprecision in `Math.sin(2 * Math.PI * tick / cycle)` would produce non-deterministic animation values.

**Before:**
```tsx
setTick((prevTick) => prevTick + 1)
```

**After:**
```tsx
setTick((prevTick) => (prevTick + 1) % Number.MAX_SAFE_INTEGER)
```

This keeps `tick` within the safe integer range while preserving the wave animation behavior, since the modulo wraps back to 0 before precision is lost.

## Scope

This is a minimal surface fix targeting integer bounds. The separate concern of CPU usage on hidden tabs (animation continuing in background) is out of scope for this change.

## Verification

- `bun run test` — all 129 tests pass
- `bun run lint` — no issues
- `bun run typecheck` — no type errors
- `madge --circular` — no circular dependencies