### PR TITLE
Fix misleading JSDoc for widthCycle and heightCycle in WaveBox

### DIFF
--- a/packages/wavebox/src/wavebox.tsx
+++ b/packages/wavebox/src/wavebox.tsx
@@ -14,8 +14,8 @@ const DEFAULT_INTERVAL = 10  // Default interval in milliseconds for the wave an
  * @param props.maxHeight - The maximum height of the WaveBox.
  * @param props.minWidth - The minimum width of the WaveBox.
  * @param props.minHeight - The minimum height of the WaveBox.
- * @param props.widthCycle - The cycle duration for the width animation.
- * @param props.heightCycle - The cycle duration for the height animation.
+ * @param props.widthCycle - The cycle length for the width animation in ticks (not milliseconds). One tick is emitted per `interval` ms. For example, widthCycle=100 with interval=10ms produces a 1-second period.
+ * @param props.heightCycle - The cycle length for the height animation in ticks (not milliseconds). One tick is emitted per `interval` ms.
  * @param props.interval - The interval in milliseconds for updating the wave animation (default is 10ms).
  * @returns {React.JSX.Element} The rendered WaveBox component.
  */
@@ -76,8 +76,8 @@ export const WaveBoxContext = React.createContext<{
  * @param props.maxHeight - The maximum height of the WaveBox.
  * @param props.minWidth - The minimum width of the WaveBox.
  * @param props.minHeight - The minimum height of the WaveBox.
- * @param props.widthCycle - The cycle duration for the width animation.
- * @param props.heightCycle - The cycle duration for the height animation.
+ * @param props.widthCycle - The cycle length for the width animation in ticks (not milliseconds). One tick is emitted per `interval` ms.
+ * @param props.heightCycle - The cycle length for the height animation in ticks (not milliseconds). One tick is emitted per `interval` ms.
  * @param props.interval - The interval in milliseconds for updating the tick state (default is 10ms).
  * @returns {React.JSX.Element} The rendered WaveBoxProvider component.
  */


### PR DESCRIPTION
## Summary

- Update JSDoc for `widthCycle` and `heightCycle` props in `WaveBox` and `WaveBoxProvider` to clarify they are measured in **ticks**, not milliseconds
- Add an example showing the relationship: `widthCycle=100` with `interval=10ms` produces a 1-second animation period

## Why

The previous JSDoc described these props as "cycle duration for the width/height animation", which implies a time unit (e.g. milliseconds). In reality, the value is a tick count — the number of ticks after which the sine wave completes one full cycle. Internally, `Math.sin(2π * tick / cycle)` shows that `cycle` divides the tick counter, not a time value.

A caller passing `widthCycle={1000}` expecting "1 second" would actually get a 10-second period (with default `interval=10ms`), because 1000 ticks × 10ms/tick = 10 seconds.

## Verification

- `bun run lint`: no issues
- `bun run typecheck`: no type errors