### PR TITLE
Wrap measureLineHeight DOM mutation in try-finally to prevent node leak

### DIFF
--- a/packages/dekamoji/src/dekamoji.tsx
+++ b/packages/dekamoji/src/dekamoji.tsx
@@ -235,9 +235,11 @@ const measureLineHeight = (
   container.style.inset = '0'
   container.appendChild(probe)
   ownerDocument.body.appendChild(container)
-  const measuredLineHeight = probe.getBoundingClientRect().height
-  ownerDocument.body.removeChild(container)
-  return measuredLineHeight
+  try {
+    return probe.getBoundingClientRect().height
+  } finally {
+    ownerDocument.body.removeChild(container)
+  }
 }
 
 const measureLineHeightRatio = (


### PR DESCRIPTION
## Summary

- Wrap the `getBoundingClientRect()` call in `measureLineHeight` with `try-finally` to guarantee the temporary container node is removed from `document.body` even if an exception is thrown

## Why

`measureLineHeight` in `packages/dekamoji/src/dekamoji.tsx` appends a temporary `<div>` to `document.body` for measurement, then removes it immediately after. However, if any exception is thrown between `appendChild` (line 237) and `removeChild` (line 239), the node is left in the document permanently.

While `getBoundingClientRect()` rarely throws itself, the pattern is a latent bug: future code additions between the two calls could introduce exceptions that silently leak invisible DOM nodes. Repeated failures would accumulate hidden `<div style="visibility:hidden; position:absolute; inset:0">` nodes in `<body>`, wasting memory and potentially affecting layout calculations.

The fix uses `try-finally` — the idiomatic JavaScript pattern for guaranteed cleanup of acquired resources.

## Verification

- `bun run lint`: no issues
- `bun run typecheck`: no type errors