### PR TITLE
fix: use monotonic clocks for stopwatch and alarm timers

### DIFF
--- a/packages/alarm/src/clock.ts
+++ b/packages/alarm/src/clock.ts
@@ -1,0 +1,3 @@
+export const getMonotonicNowMs = () => {
+  return performance.now()
+}

--- a/packages/alarm/src/context.spec.tsx
+++ b/packages/alarm/src/context.spec.tsx
@@ -46,6 +46,32 @@ describe('AlarmContextProvider', () => {
     expect(onRing).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps scheduled alarms monotonic when the wall clock moves backward', async () => {
+    const onRing = vi.fn()
+    const { getContext } = renderAlarmContext({
+      onRing,
+      refreshInterval: 10,
+    })
+
+    act(() => {
+      getContext().scheduleAfter(1)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    vi.setSystemTime(new Date('2025-12-31T23:00:00Z'))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
+
+    expect(getContext().armed).toBe(false)
+    expect(getContext().ringing).toBe(true)
+    expect(onRing).toHaveBeenCalledTimes(1)
+  })
+
   it('supports arm, disarm, notification, and reset actions', async () => {
     const onArm = vi.fn()
     const onDisarm = vi.fn()

--- a/packages/alarm/src/context.tsx
+++ b/packages/alarm/src/context.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { useInterval } from 'react-use'
 
-import { calcRemainingUntil } from './time'
+import { getMonotonicNowMs } from './clock'
+import { calcRemainingDuration, calcRemainingUntil } from './time'
 
 export interface AlarmValue {
   armed: boolean
@@ -81,11 +82,28 @@ const getActiveAlarmInterval = (armed: boolean, refreshInterval: number) => {
 }
 
 const getAlarmCurrentRemaining = (
-  targetTimeMs: number | null,
-  nowMs = Date.now()
+  targetMonotonicMs: number | null,
+  nowMonotonicMs = getMonotonicNowMs()
 ) => {
-  if (targetTimeMs === null) return 0
-  return calcRemainingUntil(targetTimeMs, nowMs)
+  if (targetMonotonicMs === null) return 0
+  return calcRemainingDuration(targetMonotonicMs, nowMonotonicMs)
+}
+
+const createAlarmTargetFromWallClock = (targetTimeMs: number) => {
+  const remaining = calcRemainingUntil(targetTimeMs, Date.now())
+  return {
+    remaining,
+    targetMonotonicMs: getMonotonicNowMs() + remaining * 1000,
+  }
+}
+
+const createAlarmTargetAfter = (seconds: number) => {
+  const remaining = Math.max(0, seconds)
+  return {
+    remaining,
+    targetMonotonicMs: getMonotonicNowMs() + remaining * 1000,
+    targetTimeMs: Date.now() + remaining * 1000,
+  }
 }
 
 const notifyAlarmRing = (
@@ -107,6 +125,7 @@ const notifyAlarmRing = (
 
 const finishAlarmRing = (props: {
   armedRef: React.MutableRefObject<boolean>
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setArmed: React.Dispatch<React.SetStateAction<boolean>>
   setRinging: React.Dispatch<React.SetStateAction<boolean>>
@@ -114,6 +133,7 @@ const finishAlarmRing = (props: {
 }) => {
   props.setRemaining(0)
   props.armedRef.current = false
+  props.targetMonotonicMsRef.current = null
   props.setArmed(false)
   props.setRinging(true)
   props.notifyRing()
@@ -121,15 +141,15 @@ const finishAlarmRing = (props: {
 
 const createAlarmTick = (props: {
   armedRef: React.MutableRefObject<boolean>
-  targetTimeMsRef: React.MutableRefObject<number | null>
-  getCurrentRemaining: (nowMs?: number) => number
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
+  getCurrentRemaining: (nowMonotonicMs?: number) => number
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setArmed: React.Dispatch<React.SetStateAction<boolean>>
   setRinging: React.Dispatch<React.SetStateAction<boolean>>
   notifyRing: () => void
 }) => {
   return () => {
-    if (shouldSkipAlarmTick(props.armedRef, props.targetTimeMsRef)) return
+    if (shouldSkipAlarmTick(props.armedRef, props.targetMonotonicMsRef)) return
     const nextRemaining = props.getCurrentRemaining()
     props.setRemaining(nextRemaining)
     handleAlarmRing(nextRemaining, props)
@@ -138,15 +158,16 @@ const createAlarmTick = (props: {
 
 const shouldSkipAlarmTick = (
   armedRef: React.MutableRefObject<boolean>,
-  targetTimeMsRef: React.MutableRefObject<number | null>
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
 ) => {
-  return !armedRef.current || targetTimeMsRef.current === null
+  return !armedRef.current || targetMonotonicMsRef.current === null
 }
 
 const handleAlarmRing = (
   nextRemaining: number,
   props: {
     armedRef: React.MutableRefObject<boolean>
+    targetMonotonicMsRef: React.MutableRefObject<number | null>
     setRemaining: React.Dispatch<React.SetStateAction<number>>
     setArmed: React.Dispatch<React.SetStateAction<boolean>>
     setRinging: React.Dispatch<React.SetStateAction<boolean>>
@@ -159,7 +180,7 @@ const handleAlarmRing = (
 
 const createAlarmArm = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
-  getCurrentRemaining: (nowMs?: number) => number
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setRinging: React.Dispatch<React.SetStateAction<boolean>>
   armedRef: React.MutableRefObject<boolean>
@@ -167,8 +188,11 @@ const createAlarmArm = (props: {
   onArm: AlarmEventHandler
 }) => {
   return () => {
-    if (props.targetTimeMsRef.current === null) return
-    props.setRemaining(props.getCurrentRemaining())
+    const targetTimeMs = props.targetTimeMsRef.current
+    if (targetTimeMs === null) return
+    const nextTarget = createAlarmTargetFromWallClock(targetTimeMs)
+    props.targetMonotonicMsRef.current = nextTarget.targetMonotonicMs
+    props.setRemaining(nextTarget.remaining)
     props.setRinging(false)
     props.armedRef.current = true
     props.setArmed(true)
@@ -178,7 +202,8 @@ const createAlarmArm = (props: {
 
 const createAlarmDisarm = (props: {
   armedRef: React.MutableRefObject<boolean>
-  getCurrentRemaining: (nowMs?: number) => number
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
+  getCurrentRemaining: (nowMonotonicMs?: number) => number
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setArmed: React.Dispatch<React.SetStateAction<boolean>>
   onDisarm: AlarmEventHandler
@@ -186,6 +211,7 @@ const createAlarmDisarm = (props: {
   return () => {
     if (!props.armedRef.current) return
     props.setRemaining(props.getCurrentRemaining())
+    props.targetMonotonicMsRef.current = null
     props.armedRef.current = false
     props.setArmed(false)
     props.onDisarm(new CustomEvent('disarm', {}))
@@ -209,6 +235,7 @@ const createAlarmToggle = (
 const createAlarmReset = (props: {
   armedRef: React.MutableRefObject<boolean>
   targetTimeMsRef: React.MutableRefObject<number | null>
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
   setArmed: React.Dispatch<React.SetStateAction<boolean>>
   setRinging: React.Dispatch<React.SetStateAction<boolean>>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
@@ -218,6 +245,7 @@ const createAlarmReset = (props: {
   return () => {
     props.armedRef.current = false
     props.targetTimeMsRef.current = null
+    props.targetMonotonicMsRef.current = null
     props.setArmed(false)
     props.setRinging(false)
     props.setRemaining(0)
@@ -228,6 +256,7 @@ const createAlarmReset = (props: {
 
 const createScheduleAlarmAfter = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
   armedRef: React.MutableRefObject<boolean>
   setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
@@ -236,11 +265,12 @@ const createScheduleAlarmAfter = (props: {
   onArm: AlarmEventHandler
 }) => {
   return (seconds: number) => {
-    const nextTargetTimeMs = Date.now() + Math.max(0, seconds) * 1000
-    props.targetTimeMsRef.current = nextTargetTimeMs
+    const nextTarget = createAlarmTargetAfter(seconds)
+    props.targetTimeMsRef.current = nextTarget.targetTimeMs
+    props.targetMonotonicMsRef.current = nextTarget.targetMonotonicMs
     props.armedRef.current = true
-    props.setTargetTimeMsState(nextTargetTimeMs)
-    props.setRemaining(Math.max(0, seconds))
+    props.setTargetTimeMsState(nextTarget.targetTimeMs)
+    props.setRemaining(nextTarget.remaining)
     props.setRinging(false)
     props.setArmed(true)
     props.onArm(new CustomEvent('arm', {}))
@@ -249,14 +279,20 @@ const createScheduleAlarmAfter = (props: {
 
 const createSetAlarmTargetTime = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
+  targetMonotonicMsRef: React.MutableRefObject<number | null>
+  armedRef: React.MutableRefObject<boolean>
   setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
   setRinging: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
   return (value: number) => {
+    const nextTarget = createAlarmTargetFromWallClock(value)
     props.targetTimeMsRef.current = value
+    props.targetMonotonicMsRef.current = props.armedRef.current
+      ? nextTarget.targetMonotonicMs
+      : null
     props.setTargetTimeMsState(value)
-    props.setRemaining(calcRemainingUntil(value))
+    props.setRemaining(nextTarget.remaining)
     props.setRinging(false)
   }
 }
@@ -303,19 +339,20 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
   )
   const armedRef = React.useRef(armed)
   const targetTimeMsRef = React.useRef<number | null>(targetTimeMs)
+  const targetMonotonicMsRef = React.useRef<number | null>(null)
   const refreshInterval = resolveAlarmRefreshInterval(props.refreshInterval)
   const notificationSupported = typeof Notification !== 'undefined'
   const notificationPermission = getNotificationPermission(notificationSupported)
 
-  const getCurrentRemaining = (nowMs = Date.now()) =>
-    getAlarmCurrentRemaining(targetTimeMsRef.current, nowMs)
+  const getCurrentRemaining = (nowMonotonicMs = getMonotonicNowMs()) =>
+    getAlarmCurrentRemaining(targetMonotonicMsRef.current, nowMonotonicMs)
 
   const notifyRing = () =>
     notifyAlarmRing(notificationEnabled, notificationSupported, onRing)
 
   const tick = createAlarmTick({
     armedRef,
-    targetTimeMsRef,
+    targetMonotonicMsRef,
     getCurrentRemaining,
     setRemaining,
     setArmed,
@@ -327,7 +364,7 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
 
   const arm = createAlarmArm({
     targetTimeMsRef,
-    getCurrentRemaining,
+    targetMonotonicMsRef,
     setRemaining,
     setRinging,
     armedRef,
@@ -337,6 +374,7 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
 
   const disarm = createAlarmDisarm({
     armedRef,
+    targetMonotonicMsRef,
     getCurrentRemaining,
     setRemaining,
     setArmed,
@@ -347,6 +385,7 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
   const reset = createAlarmReset({
     armedRef,
     targetTimeMsRef,
+    targetMonotonicMsRef,
     setArmed,
     setRinging,
     setRemaining,
@@ -358,6 +397,7 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
 
   const scheduleAfter = createScheduleAlarmAfter({
     targetTimeMsRef,
+    targetMonotonicMsRef,
     armedRef,
     setTargetTimeMsState,
     setRemaining,
@@ -368,6 +408,8 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
 
   const setTargetTimeMs = createSetAlarmTargetTime({
     targetTimeMsRef,
+    targetMonotonicMsRef,
+    armedRef,
     setTargetTimeMsState,
     setRemaining,
     setRinging,

--- a/packages/alarm/src/time.ts
+++ b/packages/alarm/src/time.ts
@@ -1,5 +1,12 @@
-export const calcRemainingUntil = (targetTimeMs: number, nowMs = Date.now()) => {
+export const calcRemainingUntil = (targetTimeMs: number, nowMs: number) => {
   return Math.max(0, (targetTimeMs - nowMs) / 1000)
+}
+
+export const calcRemainingDuration = (
+  targetMonotonicMs: number,
+  nowMonotonicMs: number
+) => {
+  return Math.max(0, (targetMonotonicMs - nowMonotonicMs) / 1000)
 }
 
 export const formatAlarmTarget = (targetTimeMs: number) => {

--- a/packages/stopwatch/src/clock.ts
+++ b/packages/stopwatch/src/clock.ts
@@ -1,0 +1,3 @@
+export const getMonotonicNowMs = () => {
+  return performance.now()
+}

--- a/packages/stopwatch/src/context.spec.tsx
+++ b/packages/stopwatch/src/context.spec.tsx
@@ -83,6 +83,29 @@ describe('StopwatchContextProvider', () => {
     expect(getContext().elapsedTime).toBe(0)
     expect(onReset).toHaveBeenCalledTimes(1)
   })
+
+  it('keeps elapsed time monotonic when the wall clock moves backward', async () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const { getContext } = renderStopwatchContext({
+      refreshInterval: 10,
+    })
+
+    act(() => {
+      getContext().start()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    vi.setSystemTime(new Date('2025-12-31T23:00:00Z'))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700)
+    })
+
+    expect(getContext().elapsedTime).toBeCloseTo(1.2, 1)
+  })
 })
 
 const renderStopwatchContext = (

--- a/packages/stopwatch/src/context.tsx
+++ b/packages/stopwatch/src/context.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { useInterval } from 'react-use'
 
+import { getMonotonicNowMs } from './clock'
+
 export interface StopwatchValue {
   elapsedTime: number
   running: boolean
@@ -64,7 +66,7 @@ const createStopwatchStart = (props: {
 }) => {
   return () => {
     if (props.running) return
-    const currentNowMs = Date.now()
+    const currentNowMs = getMonotonicNowMs()
     props.onStart(new CustomEvent('start', {}))
     props.setNowMs(currentNowMs)
     props.setStartedAtMs(currentNowMs)
@@ -84,7 +86,7 @@ const createStopwatchStop = (props: {
 }) => {
   return () => {
     if (!props.running || props.startedAtMs === null) return
-    const currentNowMs = Date.now()
+    const currentNowMs = getMonotonicNowMs()
     const nextElapsedMs = props.baseElapsedMs + (currentNowMs - props.startedAtMs)
     props.onStop(new CustomEvent('stop', {}))
     props.setNowMs(currentNowMs)
@@ -119,7 +121,7 @@ const createStopwatchReset = (props: {
     props.setRunning(false)
     props.setStartedAtMs(null)
     props.setBaseElapsedMs(0)
-    props.setNowMs(Date.now())
+    props.setNowMs(getMonotonicNowMs())
     props.onReset(new CustomEvent('reset', {}))
   }
 }
@@ -145,12 +147,12 @@ export const StopwatchContextProvider: React.FC<StopwatchProviderProps> = (
   const [running, setRunning] = React.useState(false)
   const [baseElapsedMs, setBaseElapsedMs] = React.useState(0)
   const [startedAtMs, setStartedAtMs] = React.useState<number | null>(null)
-  const [nowMs, setNowMs] = React.useState(Date.now())
+  const [nowMs, setNowMs] = React.useState(getMonotonicNowMs)
 
   const refreshInterval = resolveStopwatchRefreshInterval(props.refreshInterval)
 
   useInterval(() => {
-    setNowMs(Date.now())
+    setNowMs(getMonotonicNowMs())
   }, getActiveStopwatchInterval(running, refreshInterval))
 
   const start = createStopwatchStart({

--- a/packages/stopwatch/src/time.spec.ts
+++ b/packages/stopwatch/src/time.spec.ts
@@ -1,27 +1,19 @@
-import { describe, expect, test, } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { calcTimeDiff, calcElapsedTime } from './time'
 
-
 describe('calcElapsedTime', () => {
   test('returns elapsed time in seconds', () => {
-    const startTime = new Date('2021-01-01T00:00:00Z')
-    const elapsedTime = calcElapsedTime(startTime)
-    const expectedElapsedTime = (Date.now()- startTime.getTime()) / 1000
-    expect(elapsedTime).toBeCloseTo(expectedElapsedTime, 1)
+    expect(calcElapsedTime(1000, 2500)).toBe(1.5)
   })
 })
 
 describe('calcTimeDiff', () => {
   test('returns time difference in seconds', () => {
-    const startTime = new Date('2021-01-01T00:00:00Z')
-    const endTime = new Date('2021-01-01T00:00:01Z')
-    expect(calcTimeDiff(startTime, endTime)).toBe(1)
+    expect(calcTimeDiff(1000, 2000)).toBe(1)
   })
 
   test('returns negative value if end time is before start time', () => {
-    const startTime = new Date('2021-01-01T00:00:01Z')
-    const endTime = new Date('2021-01-01T00:00:00Z')
-    expect(calcTimeDiff(startTime, endTime)).toBe(-1)
+    expect(calcTimeDiff(2000, 1000)).toBe(-1)
   })
 })

--- a/packages/stopwatch/src/time.ts
+++ b/packages/stopwatch/src/time.ts
@@ -1,7 +1,12 @@
-export const calcTimeDiff = (startTime: Date, endTime: Date) => {
-  return (endTime.getTime() - startTime.getTime()) / 1000
+import { getMonotonicNowMs } from './clock'
+
+export const calcTimeDiff = (startTimeMs: number, endTimeMs: number) => {
+  return (endTimeMs - startTimeMs) / 1000
 }
 
-export const calcElapsedTime = (startTime: Date) => {
-  return calcTimeDiff(startTime, new Date())
+export const calcElapsedTime = (
+  startTimeMs: number,
+  nowMs = getMonotonicNowMs()
+) => {
+  return calcTimeDiff(startTimeMs, nowMs)
 }


### PR DESCRIPTION
Summary:
- use `performance.now()` for active stopwatch elapsed time
- store a monotonic alarm deadline while preserving wall-clock target display values
- add regression coverage for wall-clock rollback during stopwatch and alarm operation

Verification:
- `bun install --frozen-lockfile`
- `bun x vitest run packages/stopwatch/src/context.spec.tsx packages/stopwatch/src/time.spec.ts packages/alarm/src/context.spec.tsx`
- `bun run typecheck`
- `bun run lint`
- `bun run check-module-isolation`
- `bun run validate`
- `bun run build`
- `bun run test`
- `bun run typedoc`
- `actionlint`
- packaging dry-run for non-private packages
- `bunx madge --circular --extensions ts,tsx packages/alarm/src packages/stopwatch/src`
- `bun run test:coverage:browser:docker`
