### PR TITLE
fix(alarm,timer,metronome,stopwatch): throw instead of silent no-op when context used outside provider

### DIFF
--- a/packages/alarm/src/context.tsx
+++ b/packages/alarm/src/context.tsx
@@ -28,6 +28,10 @@ export interface AlarmActions {
 
 export type AlarmContextValue = AlarmValue & AlarmActions
 
+const missingProvider = (name: string) => (): never => {
+  throw new Error(`${name} must be used within an AlarmContextProvider`)
+}
+
 export const AlarmContext = React.createContext<AlarmContextValue>({
   armed: false,
   ringing: false,
@@ -36,15 +40,15 @@ export const AlarmContext = React.createContext<AlarmContextValue>({
   notificationEnabled: false,
   notificationSupported: false,
   notificationPermission: 'unsupported',
-  arm: () => { /* do nothing */ },
-  disarm: () => { /* do nothing */ },
-  toggle: () => { /* do nothing */ },
-  reset: () => { /* do nothing */ },
-  stopRinging: () => { /* do nothing */ },
-  scheduleAfter: (_seconds: number) => { /* do nothing */ },
-  setTargetTimeMs: (_value: number) => { /* do nothing */ },
-  setNotificationEnabled: (_value: boolean) => { /* do nothing */ },
-  toggleNotification: () => { /* do nothing */ },
+  arm: missingProvider('arm'),
+  disarm: missingProvider('disarm'),
+  toggle: missingProvider('toggle'),
+  reset: missingProvider('reset'),
+  stopRinging: missingProvider('stopRinging'),
+  scheduleAfter: missingProvider('scheduleAfter'),
+  setTargetTimeMs: missingProvider('setTargetTimeMs'),
+  setNotificationEnabled: missingProvider('setNotificationEnabled'),
+  toggleNotification: missingProvider('toggleNotification'),
 })
 
 export interface AlarmContextProviderProps {

--- a/packages/metronome/src/context.tsx
+++ b/packages/metronome/src/context.tsx
@@ -21,17 +21,21 @@ export interface MetronomeActions {
 
 export type MetronomeContextValue = MetronomeValue & MetronomeActions
 
+const missingProvider = (name: string) => (): never => {
+  throw new Error(`${name} must be used within a MetronomeContextProvider`)
+}
+
 export const MetronomeContext = React.createContext<MetronomeContextValue>({
   tempo: 120,
   running: false,
   beat: 0,
   lastBeatAtMs: null,
-  start: () => { /* do nothing */ },
-  stop: () => { /* do nothing */ },
-  toggle: () => { /* do nothing */ },
-  reset: () => { /* do nothing */ },
-  setTempo: (_value: number) => { /* do nothing */ },
-  incrementTempo: (_value: number) => { /* do nothing */ },
+  start: missingProvider('start'),
+  stop: missingProvider('stop'),
+  toggle: missingProvider('toggle'),
+  reset: missingProvider('reset'),
+  setTempo: missingProvider('setTempo'),
+  incrementTempo: missingProvider('incrementTempo'),
 })
 
 export interface MetronomeContextProviderProps {

--- a/packages/stopwatch/src/context.tsx
+++ b/packages/stopwatch/src/context.tsx
@@ -17,14 +17,18 @@ export interface StopwatchActions {
 
 export type StopwatchContextValue = StopwatchValue & StopwatchActions
 
+const missingProvider = (name: string) => (): never => {
+  throw new Error(`${name} must be used within a StopwatchContextProvider`)
+}
+
 // TODO: Support leap second: https://github.com/kitsuyui/react-playground/issues/40
 export const StopwatchContext = React.createContext<StopwatchContextValue>({
   elapsedTime: 0,
   running: false,
-  start: () => { /* do nothing */ },
-  stop: () => { /* do nothing */ },
-  toggle: () => { /* do nothing */ },
-  reset: () => { /* do nothing */ },
+  start: missingProvider('start'),
+  stop: missingProvider('stop'),
+  toggle: missingProvider('toggle'),
+  reset: missingProvider('reset'),
 })
 
 export interface StopwatchProviderProps {

--- a/packages/timer/src/context.tsx
+++ b/packages/timer/src/context.tsx
@@ -26,36 +26,24 @@ export interface TimerActions {
 
 export type TimerContextValue = TimerValue & TimerActions
 
+const missingProvider = (name: string) => (): never => {
+  throw new Error(`${name} must be used within a TimerContextProvider`)
+}
+
 // TODO: Support leap second: https://github.com/kitsuyui/react-playground/issues/40
 export const TimerContext = React.createContext<TimerContextValue>({
   remaining: 0,
   running: false,
   vibrationEnabled: false,
   vibrationSupported: false,
-  start: () => {
-    /* do nothing */
-  },
-  stop: () => {
-    /* do nothing */
-  },
-  toggle: () => {
-    /* do nothing */
-  },
-  reset: () => {
-    /* do nothing */
-  },
-  incrementTimerValue: (_value: number) => {
-    /* do nothing */
-  },
-  setTimerValue: (_value: number) => {
-    /* do nothing */
-  },
-  setVibrationEnabled: (_value: boolean) => {
-    /* do nothing */
-  },
-  toggleVibration: () => {
-    /* do nothing */
-  },
+  start: missingProvider('start'),
+  stop: missingProvider('stop'),
+  toggle: missingProvider('toggle'),
+  reset: missingProvider('reset'),
+  incrementTimerValue: missingProvider('incrementTimerValue'),
+  setTimerValue: missingProvider('setTimerValue'),
+  setVibrationEnabled: missingProvider('setVibrationEnabled'),
+  toggleVibration: missingProvider('toggleVibration'),
 })
 
 export interface TimerContextProviderProps {


### PR DESCRIPTION
## Summary

Replace silent no-op functions in `React.createContext` default values with functions that throw a descriptive `Error`. Affected packages: `alarm`, `timer`, `metronome`, `stopwatch`.

## Problem

Each context's `React.createContext()` default value contained action functions like:

```tsx
arm: () => { /* do nothing */ },
```

When a component calls `useContext(AlarmContext)` outside an `AlarmContextProvider`, these actions silently succeed — state never changes, the UI breaks, and no error or warning is emitted. The bug can go undetected for a long time.

## Fix

A local `missingProvider` factory in each context file produces a function that throws:

```tsx
const missingProvider = (name: string) => (): never => {
  throw new Error(`${name} must be used within an AlarmContextProvider`)
}

arm: missingProvider('arm'),
```

No public API surface changes. Components that correctly render inside a Provider are unaffected.

## Verification

- `bun run typecheck` — passes (no TypeScript errors)
- `bun run lint` — passes (biome, package-json sort)
- `bun run test` — all existing unit tests pass
- Circular dependency check (`madge --circular`) — no cycles
