### PR TITLE
Narrow DefaultAlarm props to only the fields it actually uses

### DIFF
--- a/packages/alarm/src/default.tsx
+++ b/packages/alarm/src/default.tsx
@@ -5,7 +5,22 @@ import { toText } from '@kitsuyui/number-time/toText'
 import type { AlarmContextValue } from './context'
 import { formatAlarmTarget } from './time'
 
-export const DefaultAlarm: React.FC<AlarmContextValue> = (props): React.JSX.Element => {
+export type DefaultAlarmProps = Pick<
+  AlarmContextValue,
+  | 'armed'
+  | 'ringing'
+  | 'remaining'
+  | 'targetTimeMs'
+  | 'notificationEnabled'
+  | 'notificationSupported'
+  | 'toggle'
+  | 'reset'
+  | 'stopRinging'
+  | 'scheduleAfter'
+  | 'toggleNotification'
+>
+
+export const DefaultAlarm: React.FC<DefaultAlarmProps> = (props): React.JSX.Element => {
   const {
     armed,
     ringing,

--- a/packages/alarm/src/index.ts
+++ b/packages/alarm/src/index.ts
@@ -6,4 +6,4 @@ export {
   type AlarmContextValue,
   type AlarmValue,
 } from './context'
-export { DefaultAlarm } from './default'
+export { DefaultAlarm, type DefaultAlarmProps } from './default'


### PR DESCRIPTION
## Summary

`DefaultAlarm` accepted the full `AlarmContextValue` type in its props but only used 11 of its 16 fields. Fields `arm`, `disarm`, `setTargetTimeMs`, `setNotificationEnabled`, and `notificationPermission` were silently ignored — a caller who passes `arm`/`disarm` callbacks will never see them invoked, because the component routes all arm/disarm interactions through `toggle` internally.

## Changes

- **`packages/alarm/src/default.tsx`**: introduce `DefaultAlarmProps` as a `Pick<AlarmContextValue, ...>` covering exactly the 11 fields the component reads. Change the component signature from `React.FC<AlarmContextValue>` to `React.FC<DefaultAlarmProps>`.
- **`packages/alarm/src/index.ts`**: re-export `DefaultAlarmProps` so consumers can reference the narrowed contract without importing internals.

`AlarmContextValue` still satisfies `DefaultAlarmProps` structurally, so existing call sites that spread the full context remain valid.

## Verification

- `bun run tsc --noEmit`: no type errors
- Format (biome): no changes needed
- Lint (biome): clean
- Tests: all pass
