### PR TITLE
fix(alarm): remove implicit ringing-stop side effect from setTargetTimeMs

### DIFF
--- a/packages/alarm/src/context.spec.tsx
+++ b/packages/alarm/src/context.spec.tsx
@@ -138,6 +138,26 @@ describe('AlarmContextProvider', () => {
     expect(getContext().remaining).toBe(0)
     expect(onReset).toHaveBeenCalledTimes(1)
   })
+
+  it('setTargetTimeMs does not stop a ringing alarm', async () => {
+    const { getContext } = renderAlarmContext({ refreshInterval: 10 })
+
+    act(() => {
+      getContext().scheduleAfter(0)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20)
+    })
+
+    expect(getContext().ringing).toBe(true)
+
+    act(() => {
+      getContext().setTargetTimeMs(Date.now() + 60_000)
+    })
+
+    expect(getContext().ringing).toBe(true)
+  })
 })
 
 const renderAlarmContext = (

--- a/packages/alarm/src/context.tsx
+++ b/packages/alarm/src/context.tsx
@@ -178,6 +178,8 @@ const handleAlarmRing = (
   finishAlarmRing(props)
 }
 
+// createAlarmArm arms the alarm at the previously set target time.
+// Arming resets the ringing state: the alarm is considered fresh-started.
 const createAlarmArm = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
   targetMonotonicMsRef: React.MutableRefObject<number | null>
@@ -254,6 +256,9 @@ const createAlarmReset = (props: {
   }
 }
 
+// createScheduleAlarmAfter arms the alarm N seconds from now (equivalent to arm
+// with an implicit setTargetTimeMs). Scheduling resets the ringing state because
+// it starts a new alarm countdown cycle.
 const createScheduleAlarmAfter = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
   targetMonotonicMsRef: React.MutableRefObject<number | null>
@@ -277,13 +282,15 @@ const createScheduleAlarmAfter = (props: {
   }
 }
 
+// createSetAlarmTargetTime updates the target time without changing the armed or
+// ringing state. Use arm() or scheduleAfter() to also start the countdown;
+// use stopRinging() to explicitly stop a ringing alarm.
 const createSetAlarmTargetTime = (props: {
   targetTimeMsRef: React.MutableRefObject<number | null>
   targetMonotonicMsRef: React.MutableRefObject<number | null>
   armedRef: React.MutableRefObject<boolean>
   setTargetTimeMsState: React.Dispatch<React.SetStateAction<number | null>>
   setRemaining: React.Dispatch<React.SetStateAction<number>>
-  setRinging: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
   return (value: number) => {
     const nextTarget = createAlarmTargetFromWallClock(value)
@@ -293,7 +300,6 @@ const createSetAlarmTargetTime = (props: {
       : null
     props.setTargetTimeMsState(value)
     props.setRemaining(nextTarget.remaining)
-    props.setRinging(false)
   }
 }
 
@@ -412,7 +418,6 @@ export const AlarmContextProvider: React.FC<AlarmContextProviderProps> = (
     armedRef,
     setTargetTimeMsState,
     setRemaining,
-    setRinging,
   })
   const setNotificationEnabledAction =
     createSetNotificationEnabledAction(setNotificationEnabled)


### PR DESCRIPTION
## Summary

`setTargetTimeMs()` was silently stopping a ringing alarm by calling
`setRinging(false)` as a side effect. This was undocumented, violated
the principle of least surprise, and made the state machine hard to
reason about.

- `arm()` and `scheduleAfter()` **intentionally** stop ringing because
  they begin a new countdown cycle (RINGING → ARMED transition).
- `setTargetTimeMs()` is a parameter setter: it updates the target time
  and should leave the ringing state unchanged.
- Callers that want to stop ringing must now call `stopRinging()` first,
  making the state transition explicit.

## Changes

- `createSetAlarmTargetTime`: remove `setRinging(false)` call and the
  now-unused `setRinging` prop.
- `createAlarmArm`, `createScheduleAlarmAfter`: add comments documenting
  that arming/scheduling intentionally resets the ringing state.
- `context.spec.tsx`: add regression test — `setTargetTimeMs` while
  ringing must leave `ringing` as `true`.

## Test plan

- `bun run test` — 9 tests pass (1 new: `setTargetTimeMs does not stop a ringing alarm`)
- `bun x tsc --noEmit` — no type errors
