### PR TITLE
Make alarm timezone and locale explicit in formatAlarmTarget

### DIFF
--- a/packages/alarm/src/default.tsx
+++ b/packages/alarm/src/default.tsx
@@ -18,7 +18,9 @@ export type DefaultAlarmProps = Pick<
   | 'stopRinging'
   | 'scheduleAfter'
   | 'toggleNotification'
->
+> & {
+  timezone?: string
+}
 
 export const DefaultAlarm: React.FC<DefaultAlarmProps> = (props): React.JSX.Element => {
   const {
@@ -33,6 +35,7 @@ export const DefaultAlarm: React.FC<DefaultAlarmProps> = (props): React.JSX.Elem
     stopRinging,
     scheduleAfter,
     toggleNotification,
+    timezone,
   } = props
   return (
     <>
@@ -45,7 +48,7 @@ export const DefaultAlarm: React.FC<DefaultAlarmProps> = (props): React.JSX.Elem
           minWidth: '9em',
         }}
       >
-        {formatAlarmStatus(ringing, targetTimeMs, remaining)}
+        {formatAlarmStatus(ringing, targetTimeMs, remaining, timezone)}
       </span>
       <button type="button" onClick={() => scheduleAfter(60)}>
         +1 min
@@ -77,11 +80,12 @@ export const DefaultAlarm: React.FC<DefaultAlarmProps> = (props): React.JSX.Elem
 const formatAlarmStatus = (
   ringing: boolean,
   targetTimeMs: number | null,
-  remaining: number
+  remaining: number,
+  timezone?: string
 ) => {
   if (ringing) return 'Alarm'
   if (targetTimeMs === null) return 'No alarm'
-  return `${toText(remaining)} -> ${formatAlarmTarget(targetTimeMs)}`
+  return `${toText(remaining)} -> ${formatAlarmTarget(targetTimeMs, timezone)}`
 }
 
 const AlarmActionButton = (props: {

--- a/packages/alarm/src/time.ts
+++ b/packages/alarm/src/time.ts
@@ -9,10 +9,12 @@ export const calcRemainingDuration = (
   return Math.max(0, (targetMonotonicMs - nowMonotonicMs) / 1000)
 }
 
-export const formatAlarmTarget = (targetTimeMs: number) => {
-  return new Intl.DateTimeFormat(undefined, {
+export const formatAlarmTarget = (targetTimeMs: number, timezone?: string): string => {
+  const timeZone = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
+  return new Intl.DateTimeFormat('en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
+    timeZone,
   }).format(new Date(targetTimeMs))
 }


### PR DESCRIPTION
## Summary

- Add an optional `timezone` parameter to `formatAlarmTarget` in `packages/alarm/src/time.ts`
- Use explicit `'en-US'` locale in `Intl.DateTimeFormat` to avoid non-ASCII digits on non-Latin locales
- Thread the new `timezone?: string` prop through `DefaultAlarm` → `formatAlarmStatus` → `formatAlarmTarget`

## Why

`formatAlarmTarget` was calling `Intl.DateTimeFormat(undefined, {...})` without a `timeZone` option, silently binding the display to the browser/server system timezone. The `clock` package in the same repo accepts an explicit `timezone: string` prop and passes it to Luxon's `setZone`. Placing alarm and clock side by side could produce time displays with different timezone bases, and SSR environments (UTC server vs. local browser) risked a hydration mismatch.

Using `Intl.DateTimeFormat(undefined, ...)` also left the locale implicit; on locales that use non-Latin digits the formatted string would contain non-ASCII characters.

## Changes

| File | Change |
|---|---|
| `packages/alarm/src/time.ts` | `formatAlarmTarget(targetTimeMs, timezone?)` — explicit `'en-US'` locale, `timeZone` from param (falls back to system TZ via `resolvedOptions`) |
| `packages/alarm/src/default.tsx` | `DefaultAlarmProps` extended with `timezone?: string`; threaded through `formatAlarmStatus` |

## Verification

- `bun run test` — 8 tests pass
- `bun run typecheck` — no errors
- `bun run lint` / `bun run format` — no issues
- `bunx madge --circular packages/alarm/src/` — no circular deps

## Trade-offs

The `timezone` prop is optional; when omitted, the fallback is `Intl.DateTimeFormat().resolvedOptions().timeZone` (system timezone), preserving the current runtime behaviour. Callers that want true alignment with the clock package must pass a matching `timezone` value explicitly.
