### PR TITLE
Remove stale rangeStrategy: bump workaround from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,4 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>kitsuyui/renovate-config'],
-  // https://github.com/renovatebot/renovate/issues/19038
-  // https://github.com/renovatebot/renovate/issues/21438
-  // TODO: remove this when renovatebot/renovate#21438 is fixed
-  rangeStrategy: 'bump',
 }


### PR DESCRIPTION
## Summary

Removes the `rangeStrategy: 'bump'` workaround and its associated comments from `.github/renovate.json5`.

The workaround referenced two upstream Renovate issues:
- [renovatebot/renovate#19038](https://github.com/renovatebot/renovate/issues/19038) — closed 2023-04-27
- [renovatebot/renovate#21438](https://github.com/renovatebot/renovate/issues/21438) — closed 2024-02-22

The TODO explicitly stated "remove this when renovatebot/renovate#21438 is fixed." That condition has been met.

Additionally, both issues were filed for **pnpm**, but this repo now uses **bun** (`packageManager: bun@1.3.11`), so the pnpm-specific workaround has no clear purpose here.

## Changes

| File | Change |
|------|--------|
| `.github/renovate.json5` | Remove `rangeStrategy: 'bump'` and associated issue-reference comments |

## Verification

Renovate will now use its default `rangeStrategy` behavior. No code logic changed.