### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,22 @@ bun run test
 bun run typecheck
 bun run validate
 ```
+
+### Local git hooks (lefthook)
+
+This repository uses [lefthook](https://github.com/evilmartians/lefthook) to run the same checks as CI before each commit and push.
+
+Install the hooks after cloning:
+
+```sh
+lefthook install
+```
+
+Hooks summary:
+
+| Hook | Scripts |
+|------|---------|
+| pre-commit | `bun run lint`, `bun run typecheck` |
+| pre-push | `bun run lint`, `bun run typecheck`, `bun run test` |
+
+CI still runs the full suite on every pull request and push to `main` — the hooks bring the same feedback earlier without leaving your editor.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+
+pre-push:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with pre-commit hooks (lint, typecheck) and pre-push hooks (lint, typecheck, test), mirroring what CI runs
- Update `README.md` with a "Local git hooks (lefthook)" subsection explaining `lefthook install` and which scripts each hook runs
- Browser/e2e scripts (`test:browser`, `test:coverage:browser`) are intentionally excluded — they require a display/browser environment
- CI workflows are untouched

## Changed files

- `lefthook.yml` (new)
- `README.md` (updated — Development section only)

## Test plan

- [ ] `lefthook install` installs hooks without error
- [ ] `git commit` triggers pre-commit: lint + typecheck both pass
- [ ] `git push` triggers pre-push: lint + typecheck + test all pass
- [ ] No CI workflow file was modified
