### PR TITLE
Add coverage acceptable thresholds to octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -3,6 +3,7 @@ coverage:
   paths:
     - coverage/unit/clover.xml
     - coverage/browser/clover.xml
+  acceptable: current >= 90%
 codeToTestRatio:
   code:
     - '**/src/**/*.ts'
@@ -12,6 +13,7 @@ codeToTestRatio:
     - '**/src/**/*.spec.tsx'
     - '**/src/**/*.browser.spec.ts'
     - '**/src/**/*.browser.spec.tsx'
+  acceptable: ratio >= 0.05
 testExecutionTime:
   if: true
 diff:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -13,7 +13,7 @@ codeToTestRatio:
     - '**/src/**/*.spec.tsx'
     - '**/src/**/*.browser.spec.ts'
     - '**/src/**/*.browser.spec.tsx'
-  acceptable: ratio >= 0.05
+  acceptable: current >= 0.05
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
## Summary

- Add `coverage.acceptable: current >= 90%` to `.octocov.yml` to gate CI on minimum coverage
- Add `codeToTestRatio.acceptable: ratio >= 0.05` to `.octocov.yml` to gate CI on code-to-test ratio

## Motivation

Coverage and code-to-test ratio were measured and reported by octocov but never gated — a drop in either metric would pass CI silently. This change adds minimum thresholds so PRs that reduce coverage below 90% or the code-to-test ratio below 0.05 will fail CI.

## Verification

- Current coverage is ~95.7% (well above the 90% threshold)
- Current code-to-test ratio is 0.1 (above the 0.05 threshold)
- Biome lint: clean
- No circular dependencies detected (madge)
