### PR TITLE
Add CONTRIBUTING.md, issue template, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a problem with a react-playground package
+labels: bug
+---
+
+## Package
+
+<!-- Which @kitsuyui/react-* package is affected? -->
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## Minimal Reproduction
+
+```tsx
+// Paste the smallest snippet or Storybook story that shows the issue.
+```
+
+## Expected Behaviour
+
+## Actual Behaviour
+
+## Environment
+
+- Package version:
+- React version:
+- Browser / runtime:
+- OS:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Affected Packages
+
+<!-- List packages under packages/ touched by this change. -->
+
+## Test Plan
+
+- [ ] `bun run lint` passes
+- [ ] `bun run typecheck` passes
+- [ ] `bun run test` passes
+- [ ] `bun run build` passes
+
+## Related Issues
+
+<!-- Closes #... -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to react-playground
+
+Thank you for your interest!
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) (see `package.json` for the expected version)
+- [lefthook](https://lefthook.dev/) for local git hooks
+
+## Setup
+
+```sh
+git clone https://github.com/kitsuyui/react-playground.git
+cd react-playground
+bun install
+lefthook install
+```
+
+## Common Commands
+
+| Command | Purpose |
+|---|---|
+| `bun run build` | Build all packages |
+| `bun run lint` | Run Biome linter |
+| `bun run typecheck` | Type-check with TypeScript |
+| `bun run test` | Run Vitest tests |
+| `bun run validate` | Run all checks |
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes, including tests for new behaviour.
+3. Run `bun run validate` to confirm everything passes.
+4. Open a pull request against `main` using the PR template.
+
+## Reporting Bugs
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md).
+Please include a minimal reproduction — a Storybook story or test snippet is ideal.
+
+## Repository Structure
+
+```
+packages/   individual @kitsuyui/react-* packages
+examples/   example applications
+config/     shared tooling configuration
+```
+
+Each package under `packages/` is an independent npm package.
+Changes to a single package should be scoped to that directory when possible.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with setup instructions, common commands, and PR workflow
- Add `.github/ISSUE_TEMPLATE/bug_report.md` with per-package context for bug reporters
- Add `.github/pull_request_template.md` with a checklist of required verifications

## Motivation

GitHub shows a `CONTRIBUTING.md` link on new issue and PR forms when the file exists.
Without it, contributors have no guided entry point, and bug reports often arrive without
the affected package name, reproduction steps, or environment details.

The PR template ensures each PR states which packages it touches and confirms that
lint, typecheck, test, and build all pass before review.

## Test Plan

- [x] `bun run lint` passes (no source changes; 189 files checked)
- [x] No collateral issues (`check-pr-collateral.py` clean)
