### PR TITLE
ci: add test and typecheck gates to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
       - name: install and build
         run: |
           bun install --frozen-lockfile
+          bun run test
+          bun run typecheck
           bun run build
           bun run validate
 


### PR DESCRIPTION
## Summary

- Added `bun run test` and `bun run typecheck` to the "install and build" step in `.github/workflows/release.yml`, before `bun run build` and `bun run validate`.

## Problem

The release workflow previously ran only `bun install`, `bun run build`, and `bun run validate`. It never ran `bun run test` or `bun run typecheck`. This meant a GitHub Release event could trigger a publish to npm from a commit that has failing tests or type errors.

This gap can be reached in practice: if test.yml CI was on a billing limit when a release tag was pushed, or the test.yml run was on a different commit, the release workflow would proceed without any test or type verification.

## What changed

```
bun install --frozen-lockfile
+ bun run test
+ bun run typecheck
  bun run build
  bun run validate
```

Tests run against `packages/*/src` directly, so the build output is not required at the point `bun run test` and `bun run typecheck` execute. Placing them before `bun run build` gives an earlier failure signal.

## Test plan

- [ ] Confirm CI passes on this PR (release workflow runs in dry-run mode on pull_request events)
- [ ] Verify that a release event would now fail fast if tests or type errors are present
