### PR TITLE
ci: reduce test workflow contents permission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 jobs:
   test:


### PR DESCRIPTION
Summary
- Reduce the test workflow GITHUB_TOKEN contents permission from write to read.
- Keep pull-requests: write for the build size report comment.

Verification
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/test.yml
- bun install --frozen-lockfile
- bun run build
- bun run lint
- bun run typecheck
- bun run check-module-isolation
- bun run test
- bun run typedoc
- bun run validate
- package dry-run loop
- collateral check: clean
