### PR TITLE
Verify Bun download checksums in Playwright Docker image

### DIFF
--- a/Dockerfile.playwright-bun
+++ b/Dockerfile.playwright-bun
@@ -1,12 +1,31 @@
 FROM mcr.microsoft.com/playwright:v1.58.1-noble
 
 ARG BUN_VERSION=1.3.11
+ARG BUN_LINUX_AMD64_SHA256=8611ba935af886f05a6f38740a15160326c15e5d5d07adef966130b4493607ed
+ARG BUN_LINUX_ARM64_SHA256=d13944da12a53ecc74bf6a720bd1d04c4555c038dfe422365356a7be47691fdf
+ARG TARGETARCH
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl unzip \
+  && apt-get install -y --no-install-recommends ca-certificates curl unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV BUN_INSTALL=/root/.bun
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
-RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
+RUN set -eux; \
+  case "${TARGETARCH}" in \
+    amd64) bun_arch="linux-x64"; bun_sha256="${BUN_LINUX_AMD64_SHA256}" ;; \
+    arm64) bun_arch="linux-aarch64"; bun_sha256="${BUN_LINUX_ARM64_SHA256}" ;; \
+    *) echo "Unsupported Bun architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  bun_zip="/tmp/bun.zip"; \
+  bun_checksum="/tmp/bun.zip.sha256"; \
+  curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${bun_arch}.zip" -o "${bun_zip}"; \
+  printf "%s  %s\n" "${bun_sha256}" "${bun_zip}" > "${bun_checksum}"; \
+  sha256sum -c "${bun_checksum}"; \
+  unzip -q "${bun_zip}" -d /tmp; \
+  mkdir -p "${BUN_INSTALL}/bin"; \
+  mv "/tmp/bun-${bun_arch}/bun" "${BUN_INSTALL}/bin/bun"; \
+  chmod +x "${BUN_INSTALL}/bin/bun"; \
+  rm -rf "/tmp/bun-${bun_arch}" "${bun_zip}" "${bun_checksum}"; \
+  bun --version


### PR DESCRIPTION
## Summary
- Replace the remote Bun installer script with direct Bun release zip downloads in the Playwright Bun Docker image.
- Select the Bun linux/amd64 or linux/arm64 asset from Docker `TARGETARCH` and verify it with a pinned SHA256 before extraction.
- Keep the image on Bun 1.3.11 and fail closed for unsupported architectures.

## Verification
- `actionlint`
- `git diff --check`
- `docker build --progress=plain -f Dockerfile.playwright-bun -t react-playground-playwright-bun:1.3.11 .`
- `docker buildx build --platform=linux/amd64 --progress=plain -f Dockerfile.playwright-bun -t react-playground-playwright-bun:1.3.11-amd64 --load .`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run test`
- `bun run typedoc`
- `bun run validate`
- `bun run test:browser:docker`
