### PR TITLE
ci: pin Dockerfile.playwright-bun base image to SHA digest

### DIFF
--- a/Dockerfile.playwright-bun
+++ b/Dockerfile.playwright-bun
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.58.1-noble
+FROM mcr.microsoft.com/playwright:v1.58.1-noble@sha256:feae0b1581609d3dc2ba22567b4703dd6a3e7a219984bb86a19ed35007148a91
 
 ARG BUN_VERSION=1.3.11
 


### PR DESCRIPTION
## Summary

- Pin `Dockerfile.playwright-bun` base image to its manifest list SHA digest.
- The image tag `mcr.microsoft.com/playwright:v1.58.1-noble` can be repointed to different content by the registry at any time; pinning to the digest ensures the same image layers are always pulled.

## Change

```diff
-FROM mcr.microsoft.com/playwright:v1.58.1-noble
+FROM mcr.microsoft.com/playwright:v1.58.1-noble@sha256:feae0b1581609d3dc2ba22567b4703dd6a3e7a219984bb86a19ed35007148a91
```

The digest (`sha256:feae0b1581609d3dc2ba22567b4703dd6a3e7a219984bb86a19ed35007148a91`) is the manifest list digest covering both `linux/amd64` and `linux/arm64` platforms, verified with:

```sh
docker buildx imagetools inspect mcr.microsoft.com/playwright:v1.58.1-noble
```

## Trade-offs

- The `renovate-config` inherited via `github>kitsuyui/renovate-config` includes `default:pinDigestsDisabled`, so Renovate will **not** automatically update this digest. When bumping `playwright` to a newer version, the digest line must also be updated manually (or by temporarily enabling `pinDigests` in the local renovate config).
- No other files changed; no test or lint changes needed.

## Verification

- `biome lint ./` — 189 files checked, no issues.
- `docker buildx imagetools inspect` — digest confirmed as the multi-arch manifest list for `v1.58.1-noble`.
