### PR TITLE
Add show props to DetailedBit

### DIFF
--- a/packages/binary/src/Detailed.spec.tsx
+++ b/packages/binary/src/Detailed.spec.tsx
@@ -32,13 +32,18 @@ describe('DetailedBit component', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('renders with little endian bit order', () => {
-    const { asFragment } = render(<DetailedBit stand={true} overflow={false} littleEndianBitOrder={1} bigEndianBitOrder={0} displayBigEndianBitOrder={true} />)
+  it('renders with big endian bit order using show prop', () => {
+    const { asFragment } = render(<DetailedBit stand={true} overflow={false} littleEndianBitOrder={1} bigEndianBitOrder={0} showBigEndianBitOrder={true} />)
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('renders with big endian bit order', () => {
-    const { asFragment } = render(<DetailedBit stand={true} overflow={false} littleEndianBitOrder={0} bigEndianBitOrder={1} displayLittleEndianBitOrder={true} />)
+  it('renders with little endian bit order using show prop', () => {
+    const { asFragment } = render(<DetailedBit stand={true} overflow={false} littleEndianBitOrder={0} bigEndianBitOrder={1} showLittleEndianBitOrder={true} />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('keeps display props as fallback aliases', () => {
+    const { asFragment } = render(<DetailedBit stand={true} overflow={false} littleEndianBitOrder={1} bigEndianBitOrder={0} displayBigEndianBitOrder={true} />)
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/packages/binary/src/Detailed.tsx
+++ b/packages/binary/src/Detailed.tsx
@@ -2,6 +2,8 @@ import type React from 'react'
 import { Bits, type EnhancedBitProps } from './Binary'
 
 export type DetailedBitProps = EnhancedBitProps & {
+  showLittleEndianBitOrder?: boolean | undefined
+  showBigEndianBitOrder?: boolean | undefined
   displayLittleEndianBitOrder?: boolean | undefined
   displayBigEndianBitOrder?: boolean | undefined
 }
@@ -52,8 +54,10 @@ const getDetailedBitPalette = (
 
 const getDetailedBitDisplayOptions = (props: DetailedBitProps) => {
   return {
-    displayLittleEndianBitOrder: props.displayLittleEndianBitOrder ?? false,
-    displayBigEndianBitOrder: props.displayBigEndianBitOrder ?? false,
+    displayLittleEndianBitOrder:
+      props.showLittleEndianBitOrder ?? props.displayLittleEndianBitOrder ?? false,
+    displayBigEndianBitOrder:
+      props.showBigEndianBitOrder ?? props.displayBigEndianBitOrder ?? false,
   }
 }
 
@@ -123,8 +127,8 @@ export const DetailedBitString = (props: DetailedBitStringProps): React.JSX.Elem
       bitElement={(props) => (
         <DetailedBit
           {...props}
-          displayLittleEndianBitOrder={showLittleEndianBitOrder}
-          displayBigEndianBitOrder={showBigEndianBitOrder}
+          showLittleEndianBitOrder={showLittleEndianBitOrder}
+          showBigEndianBitOrder={showBigEndianBitOrder}
         />
       )}
     />

--- a/packages/binary/src/__snapshots__/Detailed.spec.tsx.snap
+++ b/packages/binary/src/__snapshots__/Detailed.spec.tsx.snap
@@ -1,20 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`DetailedBit component > renders overflow with red dotted border 1`] = `
-<DocumentFragment>
-  <div
-    style="display: inline-block; font-family: monospace; margin: 0.5px;"
-  >
-    <div
-      style="color: rgb(153, 153, 153); background-color: rgb(0, 0, 0); border: 1px dotted red;"
-    >
-      1
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`DetailedBit component > renders with big endian bit order 1`] = `
+exports[`DetailedBit component > keeps display props as fallback aliases 1`] = `
 <DocumentFragment>
   <div
     style="display: inline-block; font-family: monospace; margin: 0.5px;"
@@ -33,7 +19,40 @@ exports[`DetailedBit component > renders with big endian bit order 1`] = `
 </DocumentFragment>
 `;
 
-exports[`DetailedBit component > renders with little endian bit order 1`] = `
+exports[`DetailedBit component > renders overflow with red dotted border 1`] = `
+<DocumentFragment>
+  <div
+    style="display: inline-block; font-family: monospace; margin: 0.5px;"
+  >
+    <div
+      style="color: rgb(153, 153, 153); background-color: rgb(0, 0, 0); border: 1px dotted red;"
+    >
+      1
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DetailedBit component > renders with big endian bit order using show prop 1`] = `
+<DocumentFragment>
+  <div
+    style="display: inline-block; font-family: monospace; margin: 0.5px;"
+  >
+    <div
+      style="color: rgb(153, 153, 153); background-color: rgb(0, 0, 0); border: 1px solid rgb(204, 204, 204);"
+    >
+      1
+    </div>
+    <div
+      style="user-select: none; font-size: 0.5em; text-align: center; line-height: 1em;"
+    >
+      0
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DetailedBit component > renders with little endian bit order using show prop 1`] = `
 <DocumentFragment>
   <div
     style="display: inline-block; font-family: monospace; margin: 0.5px;"


### PR DESCRIPTION
## Summary
- Add `showLittleEndianBitOrder` and `showBigEndianBitOrder` to `DetailedBitProps` so `DetailedBit` matches `DetailedBitString` naming.
- Keep the existing `display*` props as fallback aliases for compatibility.
- Pass the `show*` props from `DetailedBitString` to `DetailedBit`.

## Verification
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run test`
- `bun run typedoc`
- `bun run validate`
- package `bun pm pack --dry-run` loop
- `git diff --check`

## Notes
- Local `bun run test` exited successfully. It emitted coverage parse warnings from an ignored coverage directory outside the tracked branch diff.
