### PR TITLE
fix: preserve zero refresh intervals

### DIFF
--- a/packages/stopwatch/src/context.spec.tsx
+++ b/packages/stopwatch/src/context.spec.tsx
@@ -84,6 +84,17 @@ describe('StopwatchContextProvider', () => {
     expect(onReset).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves an explicit zero refresh interval', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const { getContext } = renderStopwatchContext({ refreshInterval: 0 })
+
+    act(() => {
+      getContext().start()
+    })
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 0)
+  })
+
   it('keeps elapsed time monotonic when the wall clock moves backward', async () => {
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
     const { getContext } = renderStopwatchContext({

--- a/packages/stopwatch/src/context.tsx
+++ b/packages/stopwatch/src/context.tsx
@@ -51,7 +51,7 @@ const resolveStopwatchHandlers = (
 })
 
 const resolveStopwatchRefreshInterval = (refreshInterval?: number) => {
-  return refreshInterval || 10
+  return refreshInterval ?? 10
 }
 
 const getActiveStopwatchInterval = (

--- a/packages/timer/src/context.spec.tsx
+++ b/packages/timer/src/context.spec.tsx
@@ -58,6 +58,20 @@ describe('TimerContextProvider', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves an explicit zero refresh interval', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const { getContext } = renderTimerContext({ refreshInterval: 0 })
+
+    act(() => {
+      getContext().setTimerValue(1)
+    })
+    act(() => {
+      getContext().start()
+    })
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 0)
+  })
+
   it('supports timer actions and completion side effects', async () => {
     const onStart = vi.fn()
     const onStop = vi.fn()

--- a/packages/timer/src/context.tsx
+++ b/packages/timer/src/context.tsx
@@ -64,7 +64,7 @@ const resolveHandler = <T,>(handler: T | undefined, fallback: T): T => {
 }
 
 const resolveTimerRefreshInterval = (refreshInterval?: number) => {
-  return refreshInterval || 10
+  return refreshInterval ?? 10
 }
 
 const resolveVibrationPattern = (pattern?: number | number[]) => {


### PR DESCRIPTION
## Summary
- Preserve explicit `refreshInterval={0}` values in timer and stopwatch providers.
- Add regression coverage for zero refresh intervals in both context providers.
- Align timer and stopwatch defaulting with the existing nullish semantics used by the other interval-based providers.

## Verification
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run test`
- `bun run typedoc`
- `bun run validate`
- `actionlint .github/workflows/*.yml`
- package `bun pm pack --dry-run` loop
- `git diff --check`
- collateral check: clean
- foreground implement-validator verdict: overall pass
