### PR TITLE
Parallelize independent workflow checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,17 +59,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: typecheck
-        run: bun run typecheck
+          - name: typecheck
+            run: bun run typecheck
 
-      - name: Check module isolation
-        run: bun run check-module-isolation
+          - name: Check module isolation
+            run: bun run check-module-isolation
 
-      - name: Test
-        run: bun run test
+          - name: Test
+            run: bun run test
 
       - name: Try to build docs
         run: bun run typedoc


### PR DESCRIPTION
## Summary
- Run independent post-build lint, type-check, module-isolation, and test steps through a GitHub Actions `parallel` group.
- Keep the required build step before the group and docs/package checks after it.

## Verification
- Parsed the updated workflow as YAML.
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run test`
- `bun run typedoc`
- `bun run validate`
- package dry-run loop from the workflow
