### PR TITLE
Replace the invalid `parallel:` step in `.github/workflows/test.yml` wi…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,18 +59,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - parallel:
-          - name: Lint
-            run: bun run lint
+      - name: Lint
+        run: bun run lint
 
-          - name: typecheck
-            run: bun run typecheck
+      - name: typecheck
+        run: bun run typecheck
 
-          - name: Check module isolation
-            run: bun run check-module-isolation
+      - name: Check module isolation
+        run: bun run check-module-isolation
 
-          - name: Test
-            run: bun run test
+      - name: Test
+        run: bun run test
 
       - name: Try to build docs
         run: bun run typedoc


### PR DESCRIPTION
## Summary

Replace the invalid `parallel:` step in `.github/workflows/test.yml` with ordinary GitHub Actions steps so the test workflow parses and runs normally.

## Chosen fix

- approach: surface
