### PR TITLE
Add job-level timeout bounds to the long-running GitHub Actions workflo…

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:
@@ -58,6 +59,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 60
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   octocov:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Add job-level timeout bounds to the long-running GitHub Actions workflows so hung CI runs fail closed instead of blocking PRs or main indefinitely.

## Chosen fix

- approach: surface
The issue is operational rather than structural: adding explicit job timeouts is the smallest repo-local change that constrains runaway runs without changing workflow intent, settings, or supported runtimes.
