### PR TITLE
test(treemap): cover boustrophedon direction and pre-measurement branches

### DIFF
--- a/packages/treemap/src/__snapshots__/treemap.spec.tsx.snap
+++ b/packages/treemap/src/__snapshots__/treemap.spec.tsx.snap
@@ -1,5 +1,163 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SizedTreemap > renders the boustrophedon, horizontal-first layout without crashing 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 640px; height: 360px; position: absolute; overflow: hidden;"
+  >
+    <div
+      style="position: absolute; overflow: hidden; width: 233.9576873779297px; height: 145.70053100585938px; left: 0px; top: 0px;"
+    >
+      <div>
+        Test10
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 212.68878173828125px; height: 145.70053100585938px; left: 233.9576873779297px; top: 0px;"
+    >
+      <div>
+        Test9
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 193.353515625px; height: 145.70053100585938px; left: 446.646484375px; top: 0px;"
+    >
+      <div>
+        Test8
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 183.546630859375px; height: 139.53204345703125px; left: 456.453369140625px; top: 145.70053100585938px;"
+    >
+      <div>
+        Test7
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 166.860595703125px; height: 139.53204345703125px; left: 289.5927734375px; top: 145.70053100585938px;"
+    >
+      <div>
+        Test6
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 151.6914520263672px; height: 139.53204345703125px; left: 137.9013214111328px; top: 145.70053100585938px;"
+    >
+      <div>
+        Test5
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 137.9013214111328px; height: 139.53204345703125px; left: 0px; top: 145.70053100585938px;"
+    >
+      <div>
+        Test4
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 233.9576873779297px; height: 74.76742553710938px; left: 0px; top: 285.2325744628906px;"
+    >
+      <div>
+        Test3
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 212.68882751464844px; height: 74.76742553710938px; left: 233.9576873779297px; top: 285.2325744628906px;"
+    >
+      <div>
+        Test2
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 193.3534698486328px; height: 74.76742553710938px; left: 446.6465148925781px; top: 285.2325744628906px;"
+    >
+      <div>
+        Test1
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SizedTreemap > renders the boustrophedon, vertical-first layout without crashing 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 360px; height: 640px; position: absolute; overflow: hidden;"
+  >
+    <div
+      style="position: absolute; overflow: hidden; width: 145.70053100585938px; height: 233.9576873779297px; left: 0px; top: 0px;"
+    >
+      <div>
+        Test10
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 145.70053100585938px; height: 212.68878173828125px; left: 0px; top: 233.9576873779297px;"
+    >
+      <div>
+        Test9
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 145.70053100585938px; height: 193.353515625px; left: 0px; top: 446.646484375px;"
+    >
+      <div>
+        Test8
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 139.53204345703125px; height: 183.546630859375px; left: 145.70053100585938px; top: 456.453369140625px;"
+    >
+      <div>
+        Test7
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 139.53204345703125px; height: 166.860595703125px; left: 145.70053100585938px; top: 289.5927734375px;"
+    >
+      <div>
+        Test6
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 139.53204345703125px; height: 151.6914520263672px; left: 145.70053100585938px; top: 137.9013214111328px;"
+    >
+      <div>
+        Test5
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 139.53204345703125px; height: 137.9013214111328px; left: 145.70053100585938px; top: 0px;"
+    >
+      <div>
+        Test4
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 74.76742553710938px; height: 233.9576873779297px; left: 285.2325744628906px; top: 0px;"
+    >
+      <div>
+        Test3
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 74.76742553710938px; height: 212.68882751464844px; left: 285.2325744628906px; top: 233.9576873779297px;"
+    >
+      <div>
+        Test2
+      </div>
+    </div>
+    <div
+      style="position: absolute; overflow: hidden; width: 74.76742553710938px; height: 193.3534698486328px; left: 285.2325744628906px; top: 446.6465148925781px;"
+    >
+      <div>
+        Test1
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SizedTreemap > renders without crashing 1`] = `
 <DocumentFragment>
   <div

--- a/packages/treemap/src/treemap.auto.spec.tsx
+++ b/packages/treemap/src/treemap.auto.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@testing-library/react'
+import { AutoTreemap } from './treemap'
+
+const { useMeasureMock } = vi.hoisted(() => ({
+  useMeasureMock: vi.fn(),
+}))
+
+vi.mock('react-use', async () => {
+  const actual = await vi.importActual<typeof import('react-use')>('react-use')
+  return {
+    ...actual,
+    useMeasure: useMeasureMock,
+  }
+})
+
+describe('AutoTreemap', () => {
+  it('renders nothing before the parent has been measured', () => {
+    useMeasureMock.mockReturnValue([vi.fn(), { width: 0, height: 0 }])
+
+    const { queryByText } = render(
+      <AutoTreemap
+        weightedItems={[{ weight: 1, element: <div>Test</div> }]}
+      />
+    )
+
+    expect(queryByText('Test')).toBeNull()
+  })
+
+  it('renders the measured layout once the parent has a size', () => {
+    useMeasureMock.mockReturnValue([vi.fn(), { width: 200, height: 100 }])
+
+    const { getByText } = render(
+      <AutoTreemap
+        weightedItems={[{ weight: 1, element: <div>Test</div> }]}
+      />
+    )
+
+    expect(getByText('Test')).toBeTruthy()
+  })
+})

--- a/packages/treemap/src/treemap.spec.tsx
+++ b/packages/treemap/src/treemap.spec.tsx
@@ -21,4 +21,51 @@ describe('SizedTreemap', () => {
     await new Promise((resolve) => setTimeout(resolve, 100)) // Wait for effects to settle
     expect(asFragment()).toMatchSnapshot()
   })
+
+  const boustrophedonWeightedItems = () => {
+    const weightedItems = [...Array(10)]
+      .map((_, index) => index + 1)
+      .map((index) => ({
+        weight: 1.1 ** index,
+        element: <div>{`Test${index}`}</div>,
+      }))
+    weightedItems.sort((left, right) => right.weight - left.weight)
+    return weightedItems
+  }
+
+  it('renders the boustrophedon, horizontal-first layout without crashing', async () => {
+    // Row-major zig-zag: alternating rows reverse the x axis (right, then left).
+    const { asFragment } = render(
+      <SizedTreemap
+        weightedItems={boustrophedonWeightedItems()}
+        verticalFirst={false}
+        aspectRatio={16 / 9}
+        boustrophedon={true}
+        width={640}
+        height={360}
+      />
+    )
+    await userEvent.click(document.body) // Trigger any potential effects
+    fireEvent.resize(window) // Simulate a resize event
+    await new Promise((resolve) => setTimeout(resolve, 100)) // Wait for effects to settle
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders the boustrophedon, vertical-first layout without crashing', async () => {
+    // Column-major zig-zag: alternating columns reverse the y axis (down, then up).
+    const { asFragment } = render(
+      <SizedTreemap
+        weightedItems={boustrophedonWeightedItems()}
+        verticalFirst={true}
+        aspectRatio={9 / 16}
+        boustrophedon={true}
+        width={360}
+        height={640}
+      />
+    )
+    await userEvent.click(document.body) // Trigger any potential effects
+    fireEvent.resize(window) // Simulate a resize event
+    await new Promise((resolve) => setTimeout(resolve, 100)) // Wait for effects to settle
+    expect(asFragment()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
## Background

Finding `metric-audit-001` (repo audit) flagged that `packages/treemap/src/treemap.tsx`
had only 44% branch coverage. `AutoTreemap` / `SizedTreemap` publish `verticalFirst`
and `boustrophedon` as part of their documented API (README, Storybook), and
`AutoTreemap` guards rendering on the parent measurement, but the existing tests
only ever exercised the default `verticalFirst=true, boustrophedon=false` path.

Concretely, `coverage/coverage-final.json` showed these branches as never taken:

- `treemap.tsx:94` — the `left` and `up` cases of the direction-inversion `switch`
- `treemap.tsx:209` — both arms of `AutoTreemap`'s pre-measurement ternary

Storybook's `Context.stories.tsx` already demos `verticalFirst: false,
boustrophedon: true`, so this is a real, user-reachable configuration that
had no regression safety net.

## Changes

- `packages/treemap/src/treemap.spec.tsx`: add a horizontal-first
  (`verticalFirst: false, boustrophedon: true`) and a vertical-first
  (`verticalFirst: true, boustrophedon: true`) `SizedTreemap` case, so the
  reversed reading order is exercised on both the x and y axis.
- `packages/treemap/src/treemap.auto.spec.tsx` (new): mock `react-use`'s
  `useMeasure` to render `AutoTreemap` both before and after the parent has
  been measured, covering the `width > 0 && height > 0` guard.
- `packages/treemap/src/__snapshots__/treemap.spec.tsx.snap`: updated
  snapshot for the new `SizedTreemap` cases.

No production code, dependencies, or CI configuration changed — this only
adds test coverage using the existing Vitest setup.

## Verification

- `bunx vitest run packages/*/src` — all 251 unit tests pass (no regressions).
- `bunx vitest run --coverage packages/treemap/src` —
  `treemap.tsx` branch coverage: 44% → 94.4% (stmt/line/func coverage: 100%).
  The one remaining uncovered branch (`?? 'right'` fallback in
  `nextBoustrophedonDirection`) only guards the case where no direction
  predicate matches two identical rectangles, which does not occur for real
  layouts.
- `bunx biome lint packages/treemap/src` — no issues.
- `bunx tsc --project tsconfig.json` — no errors.
